### PR TITLE
feat: return the correct size for custom container objects

### DIFF
--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import io
 import warnings
 from pathlib import Path
@@ -627,3 +628,13 @@ class Image:
             )
         else:
             return Image(edges_tensor, device=self.device)
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return sys.getsizeof(self._image_tensor) + self._image_tensor.element_size() * self._image_tensor.nelement()

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import io
 from collections.abc import Sequence
 from numbers import Number
@@ -1032,3 +1033,13 @@ class Column(Sequence[T]):
         2
         """
         return self._data.isna().sum()
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return sys.getsizeof(self._data) + sys.getsizeof(self._name) + sys.getsizeof(self._type)

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import functools
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -530,3 +531,13 @@ class Row(Mapping[str, Any]):
             The generated HTML.
         """
         return self._data.to_html(max_rows=1, max_cols=self._data.shape[1], notebook=True)
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return sys.getsizeof(self._data) + sys.getsizeof(self._schema)

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import functools
 import io
 import warnings
@@ -2369,3 +2370,13 @@ class Table:
         data_copy = self._data.reset_index(drop=True)
         data_copy.columns = self.column_names
         return data_copy.__dataframe__(nan_as_null, allow_copy)
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return sys.getsizeof(self._data) + sys.getsizeof(self._schema)

--- a/src/safeds/data/tabular/containers/_tagged_table.py
+++ b/src/safeds/data/tabular/containers/_tagged_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from safeds.data.tabular.containers import Column, Row, Table
@@ -833,3 +834,13 @@ class TaggedTable(Table):
             target_name=self.target.name,
             feature_names=self.features.column_names,
         )
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return Table.__sizeof__(self) + sys.getsizeof(self._features) + sys.getsizeof(self._target)

--- a/src/safeds/data/tabular/containers/_time_series.py
+++ b/src/safeds/data/tabular/containers/_time_series.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from safeds.data.tabular.containers import Column, Row, Table, TaggedTable
@@ -846,3 +847,13 @@ class TimeSeries(TaggedTable):
             ),
             time_name=self.time.name,
         )
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return TaggedTable.__sizeof__(self) + sys.getsizeof(self._time)

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -305,3 +306,13 @@ class Schema:
         lines = (f"| {name} | {type_} |" for name, type_ in self._schema.items())
         joined = "\n".join(lines)
         return f"| Column Name | Column Type |\n| --- | --- |\n{joined}"
+
+    def __sizeof__(self) -> int:
+        """
+        Return the complete size of this object.
+
+        Returns
+        -------
+        Size of this object in bytes.
+        """
+        return sys.getsizeof(self._schema)

--- a/tests/safeds/data/image/containers/test_image.py
+++ b/tests/safeds/data/image/containers/test_image.py
@@ -1,3 +1,4 @@
+import sys
 import typing
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -900,3 +901,16 @@ class TestFindEdges:
         image_edges = image.find_edges()
         assert image_edges == snapshot_png
         _assert_width_height_channel(image, image_edges)
+
+
+@pytest.mark.parametrize("device", _test_devices(), ids=_test_devices_ids())
+class TestSizeof:
+    @pytest.mark.parametrize(
+        "resource_path",
+        _test_images_all(),
+        ids=_test_images_all_ids(),
+    )
+    def test_should_size_be_greater_than_normal_object(self, resource_path: str | Path, device: Device) -> None:
+        _skip_if_device_not_available(device)
+        image = Image.from_file(resolve_resource_path(resource_path), device)
+        assert sys.getsizeof(image) >= image.width * image.height * image.channel

--- a/tests/safeds/data/tabular/containers/_column/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_column/test_sizeof.py
@@ -1,0 +1,21 @@
+import sys
+
+import pytest
+from safeds.data.tabular.containers import Column
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        Column("a", []),
+        Column("a", [0]),
+        Column("a", [0, "1"]),
+    ],
+    ids=[
+        "empty",
+        "one row",
+        "multiple rows",
+    ],
+)
+def test_should_size_be_greater_than_normal_object(column: Column) -> None:
+    assert sys.getsizeof(column) > sys.getsizeof(object())

--- a/tests/safeds/data/tabular/containers/_table/_tagged_table/_time_series/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_table/_tagged_table/_time_series/test_sizeof.py
@@ -1,0 +1,39 @@
+import sys
+
+import pytest
+from safeds.data.tabular.containers import Table, TimeSeries
+
+
+@pytest.mark.parametrize(
+    "time_series",
+    [
+
+            TimeSeries(
+                {
+                    "time": [0, 1, 2],
+                    "feature_1": [3, 9, 6],
+                    "feature_2": [6, 12, 9],
+                    "target": [1, 3, 2],
+                },
+                "target",
+                "time",
+                ["feature_1", "feature_2"],
+            ),
+
+            TimeSeries(
+                {
+                    "time": [0, 1, 2],
+                    "feature_1": [3, 9, 6],
+                    "feature_2": [6, 12, 9],
+                    "other": [3, 9, 12],
+                    "target": [1, 3, 2],
+                },
+                "target",
+                "time",
+                ["feature_1", "feature_2"],
+            ),
+    ],
+    ids=["normal", "table_with_column_as_non_feature"],
+)
+def test_should_size_be_greater_than_normal_object(time_series: TimeSeries) -> None:
+    assert sys.getsizeof(time_series) > sys.getsizeof(object())

--- a/tests/safeds/data/tabular/containers/_table/_tagged_table/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_table/_tagged_table/test_sizeof.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+from safeds.data.tabular.containers import Table, TaggedTable
+
+
+@pytest.mark.parametrize(
+    "tagged_table",
+    [
+
+            TaggedTable(
+                {
+                    "feature_1": [3, 9, 6],
+                    "feature_2": [6, 12, 9],
+                    "target": [1, 3, 2],
+                },
+                "target",
+                ["feature_1", "feature_2"],
+            ),
+
+            TaggedTable(
+                {
+                    "feature_1": [3, 9, 6],
+                    "feature_2": [6, 12, 9],
+                    "other": [3, 9, 12],
+                    "target": [1, 3, 2],
+                },
+                "target",
+                ["feature_1", "feature_2"],
+            ),
+    ],
+    ids=["normal", "table_with_column_as_non_feature"],
+)
+def test_should_size_be_greater_than_normal_object(tagged_table: TaggedTable) -> None:
+    assert sys.getsizeof(tagged_table) > sys.getsizeof(object())

--- a/tests/safeds/data/tabular/containers/_table/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sizeof.py
@@ -1,0 +1,21 @@
+import sys
+
+import pytest
+from safeds.data.tabular.containers import Table
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        Table(),
+        Table({"col1": [0]}),
+        Table({"col1": [0, "1"], "col2": ["a", "b"]}),
+    ],
+    ids=[
+        "empty table",
+        "table with one row",
+        "table with multiple rows",
+    ],
+)
+def test_should_size_be_greater_than_normal_object(table: Table) -> None:
+    assert sys.getsizeof(table) > sys.getsizeof(object())

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -552,3 +553,21 @@ class TestSortColumns:
     def test_should_sort_table_out_of_place(self, row: Row) -> None:
         sorted_row = row.sort_columns()
         assert sorted_row != row
+
+
+class TestSizeof:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            Row(),
+            Row({"col1": 0}),
+            Row({"col1": 0, "col2": "a"}),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ],
+    )
+    def test_should_size_be_greater_than_normal_object(self, row: Row) -> None:
+        assert sys.getsizeof(row) > sys.getsizeof(object())

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -495,3 +496,21 @@ class TestReprMarkdown:
     )
     def test_should_create_a_string_representation(self, schema: Schema, expected: str) -> None:
         assert schema._repr_markdown_() == expected
+
+
+class TestSizeof:
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            Schema({}),
+            Schema({"A": Integer()}),
+            Schema({"A": Integer(), "B": String()}),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ],
+    )
+    def test_should_size_be_greater_than_normal_object(self, schema: Schema) -> None:
+        assert sys.getsizeof(schema) > sys.getsizeof(object())


### PR DESCRIPTION
This is needed to correctly evaluate whether an object is worth memoizing or keeping in the cache.

See for context: https://github.com/Safe-DS/Runner/pull/51 and https://github.com/Safe-DS/Runner/issues/44

For future container classes (like e.g. image set this would also need to be added, to be compatible with the memoizing implementation in the runner)
