### PR TITLE
feat: add suffixes to models to indicate their task

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,7 +25,7 @@ It classifies the predictions to be either be [true positive](#true-positive-tp)
 ## Decision Tree
 A Decision Tree represents the process of conditional evaluation in a tree diagram.
 
-Implemented in Safe-DS as [Decision Tree][safeds.ml.classical.classification.DecisionTree].
+Implemented in Safe-DS as [DecisionTreeClassifier][safeds.ml.classical.classification.DecisionTreeClassifier] and [DecisionTreeRegressor][safeds.ml.classical.regression.DecisionTreeRegressor].
 
 ## F1-Score
 The harmonic mean of [precision](#precision) and [recall](#recall). Formula:
@@ -48,7 +48,7 @@ It is analogous to a column within a table.
 Linear Regression is the supervised Machine Learning model in which the model finds the best fit linear line between the independent and dependent variable
 i.e. it finds the linear relationship between the dependent and independent variable.
 
-Implemented in Safe-DS as [LinearRegression][safeds.ml.classical.regression.LinearRegression].
+Implemented in Safe-DS as [LinearRegression][safeds.ml.classical.regression.LinearRegressionRegressor].
 
 ## Machine Learning (ML)
 Machine Learning is a generic term for artificially generating knowledge through experience.
@@ -84,7 +84,7 @@ See here for respective references:
 ## Random Forest
 Random Forest is an ML model that works by generating decision trees at random.
 
-Implemented in Safe-DS as [RandomForest][safeds.ml.classical.regression.RandomForest].
+Implemented in Safe-DS as [RandomForestClassifier][safeds.ml.classical.classification.RandomForestClassifier] and [RandomForestRegressor][safeds.ml.classical.regression.RandomForestRegressor].
 
 ## Recall
 The ability of a [classification](#classification) model to identify all the relevant data points. Formula:

--- a/docs/tutorials/classification.ipynb
+++ b/docs/tutorials/classification.ipynb
@@ -145,9 +145,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from safeds.ml.classical.classification import RandomForest\n",
+    "from safeds.ml.classical.classification import RandomForestClassifier\n",
     "\n",
-    "model = RandomForest()\n",
+    "model = RandomForestClassifier()\n",
     "fitted_model= model.fit(tagged_train_table)"
    ],
    "metadata": {

--- a/docs/tutorials/machine_learning.ipynb
+++ b/docs/tutorials/machine_learning.ipynb
@@ -54,9 +54,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from safeds.ml.classical.regression import LinearRegression\n",
+    "from safeds.ml.classical.regression import LinearRegressionRegressor\n",
     "\n",
-    "model = LinearRegression()\n",
+    "model = LinearRegressionRegressor()\n",
     "fitted_model = model.fit(tagged_table)"
    ],
    "metadata": {

--- a/docs/tutorials/regression.ipynb
+++ b/docs/tutorials/regression.ipynb
@@ -98,9 +98,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from safeds.ml.classical.regression import DecisionTree\n",
+    "from safeds.ml.classical.regression import DecisionTreeRegressor\n",
     "\n",
-    "model = DecisionTree()\n",
+    "model = DecisionTreeRegressor()\n",
     "fitted_model = model.fit(tagged_train_table)"
    ],
    "metadata": {

--- a/src/safeds/ml/classical/classification/__init__.py
+++ b/src/safeds/ml/classical/classification/__init__.py
@@ -1,21 +1,21 @@
 """Classes for classification tasks."""
 
-from ._ada_boost import AdaBoost
+from ._ada_boost import AdaBoostClassifier
 from ._classifier import Classifier
-from ._decision_tree import DecisionTree
-from ._gradient_boosting import GradientBoosting
-from ._k_nearest_neighbors import KNearestNeighbors
-from ._logistic_regression import LogisticRegression
-from ._random_forest import RandomForest
-from ._support_vector_machine import SupportVectorMachine
+from ._decision_tree import DecisionTreeClassifier
+from ._gradient_boosting import GradientBoostingClassifier
+from ._k_nearest_neighbors import KNearestNeighborsClassifier
+from ._logistic_regression import LogisticRegressionClassifier
+from ._random_forest import RandomForestClassifier
+from ._support_vector_machine import SupportVectorMachineClassifier
 
 __all__ = [
-    "AdaBoost",
+    "AdaBoostClassifier",
     "Classifier",
-    "DecisionTree",
-    "GradientBoosting",
-    "KNearestNeighbors",
-    "LogisticRegression",
-    "RandomForest",
-    "SupportVectorMachine",
+    "DecisionTreeClassifier",
+    "GradientBoostingClassifier",
+    "KNearestNeighborsClassifier",
+    "LogisticRegressionClassifier",
+    "RandomForestClassifier",
+    "SupportVectorMachineClassifier",
 ]

--- a/src/safeds/ml/classical/classification/_ada_boost.py
+++ b/src/safeds/ml/classical/classification/_ada_boost.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class AdaBoost(Classifier):
+class AdaBoostClassifier(Classifier):
     """
     Ada Boost classification.
 
@@ -99,7 +99,7 @@ class AdaBoost(Classifier):
         """
         return self._learning_rate
 
-    def fit(self, training_set: TaggedTable) -> AdaBoost:
+    def fit(self, training_set: TaggedTable) -> AdaBoostClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -112,7 +112,7 @@ class AdaBoost(Classifier):
 
         Returns
         -------
-        fitted_classifier : AdaBoost
+        fitted_classifier : AdaBoostClassifier
             The fitted classifier.
 
         Raises
@@ -131,7 +131,7 @@ class AdaBoost(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = AdaBoost(
+        result = AdaBoostClassifier(
             learner=self.learner,
             maximum_number_of_learners=self.maximum_number_of_learners,
             learning_rate=self._learning_rate,

--- a/src/safeds/ml/classical/classification/_decision_tree.py
+++ b/src/safeds/ml/classical/classification/_decision_tree.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class DecisionTree(Classifier):
+class DecisionTreeClassifier(Classifier):
     """Decision tree classification."""
 
     def __init__(self) -> None:
@@ -23,7 +23,7 @@ class DecisionTree(Classifier):
         self._feature_names: list[str] | None = None
         self._target_name: str | None = None
 
-    def fit(self, training_set: TaggedTable) -> DecisionTree:
+    def fit(self, training_set: TaggedTable) -> DecisionTreeClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -36,7 +36,7 @@ class DecisionTree(Classifier):
 
         Returns
         -------
-        fitted_classifier : DecisionTree
+        fitted_classifier : DecisionTreeClassifier
             The fitted classifier.
 
         Raises
@@ -55,7 +55,7 @@ class DecisionTree(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = DecisionTree()
+        result = DecisionTreeClassifier()
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/classification/_gradient_boosting.py
+++ b/src/safeds/ml/classical/classification/_gradient_boosting.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class GradientBoosting(Classifier):
+class GradientBoostingClassifier(Classifier):
     """
     Gradient boosting classification.
 
@@ -74,7 +74,7 @@ class GradientBoosting(Classifier):
         """
         return self._learning_rate
 
-    def fit(self, training_set: TaggedTable) -> GradientBoosting:
+    def fit(self, training_set: TaggedTable) -> GradientBoostingClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -87,7 +87,7 @@ class GradientBoosting(Classifier):
 
         Returns
         -------
-        fitted_classifier : GradientBoosting
+        fitted_classifier : GradientBoostingClassifier
             The fitted classifier.
 
         Raises
@@ -106,7 +106,7 @@ class GradientBoosting(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = GradientBoosting(number_of_trees=self._number_of_trees, learning_rate=self._learning_rate)
+        result = GradientBoostingClassifier(number_of_trees=self._number_of_trees, learning_rate=self._learning_rate)
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class KNearestNeighbors(Classifier):
+class KNearestNeighborsClassifier(Classifier):
     """
     K-nearest-neighbors classification.
 
@@ -56,7 +56,7 @@ class KNearestNeighbors(Classifier):
         """
         return self._number_of_neighbors
 
-    def fit(self, training_set: TaggedTable) -> KNearestNeighbors:
+    def fit(self, training_set: TaggedTable) -> KNearestNeighborsClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -69,7 +69,7 @@ class KNearestNeighbors(Classifier):
 
         Returns
         -------
-        fitted_classifier : KNearestNeighbors
+        fitted_classifier : KNearestNeighborsClassifier
             The fitted classifier.
 
         Raises
@@ -99,7 +99,7 @@ class KNearestNeighbors(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = KNearestNeighbors(self._number_of_neighbors)
+        result = KNearestNeighborsClassifier(self._number_of_neighbors)
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/classification/_logistic_regression.py
+++ b/src/safeds/ml/classical/classification/_logistic_regression.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class LogisticRegression(Classifier):
+class LogisticRegressionClassifier(Classifier):
     """Regularized logistic regression."""
 
     def __init__(self) -> None:
@@ -23,7 +23,7 @@ class LogisticRegression(Classifier):
         self._feature_names: list[str] | None = None
         self._target_name: str | None = None
 
-    def fit(self, training_set: TaggedTable) -> LogisticRegression:
+    def fit(self, training_set: TaggedTable) -> LogisticRegressionClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -36,7 +36,7 @@ class LogisticRegression(Classifier):
 
         Returns
         -------
-        fitted_classifier : LogisticRegression
+        fitted_classifier : LogisticRegressionClassifier
             The fitted classifier.
 
         Raises
@@ -55,7 +55,7 @@ class LogisticRegression(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = LogisticRegression()
+        result = LogisticRegressionClassifier()
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/classification/_random_forest.py
+++ b/src/safeds/ml/classical/classification/_random_forest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class RandomForest(Classifier):
+class RandomForestClassifier(Classifier):
     """Random forest classification.
 
     Parameters
@@ -54,7 +54,7 @@ class RandomForest(Classifier):
         """
         return self._number_of_trees
 
-    def fit(self, training_set: TaggedTable) -> RandomForest:
+    def fit(self, training_set: TaggedTable) -> RandomForestClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -67,7 +67,7 @@ class RandomForest(Classifier):
 
         Returns
         -------
-        fitted_classifier : RandomForest
+        fitted_classifier : RandomForestClassifier
             The fitted classifier.
 
         Raises
@@ -86,7 +86,7 @@ class RandomForest(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = RandomForest(number_of_trees=self._number_of_trees)
+        result = RandomForestClassifier(number_of_trees=self._number_of_trees)
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/classification/_support_vector_machine.py
+++ b/src/safeds/ml/classical/classification/_support_vector_machine.py
@@ -30,7 +30,7 @@ class SupportVectorMachineKernel(ABC):
         """
 
 
-class SupportVectorMachine(Classifier):
+class SupportVectorMachineClassifier(Classifier):
     """
     Support vector machine.
 
@@ -151,18 +151,18 @@ class SupportVectorMachine(Classifier):
         TypeError
             If the kernel type is invalid.
         """
-        if isinstance(self.kernel, SupportVectorMachine.Kernel.Linear):
+        if isinstance(self.kernel, SupportVectorMachineClassifier.Kernel.Linear):
             return "linear"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.Polynomial):
+        elif isinstance(self.kernel, SupportVectorMachineClassifier.Kernel.Polynomial):
             return "poly"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.Sigmoid):
+        elif isinstance(self.kernel, SupportVectorMachineClassifier.Kernel.Sigmoid):
             return "sigmoid"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.RadialBasisFunction):
+        elif isinstance(self.kernel, SupportVectorMachineClassifier.Kernel.RadialBasisFunction):
             return "rbf"
         else:
             raise TypeError("Invalid kernel type.")
 
-    def fit(self, training_set: TaggedTable) -> SupportVectorMachine:
+    def fit(self, training_set: TaggedTable) -> SupportVectorMachineClassifier:
         """
         Create a copy of this classifier and fit it with the given training data.
 
@@ -175,7 +175,7 @@ class SupportVectorMachine(Classifier):
 
         Returns
         -------
-        fitted_classifier : SupportVectorMachine
+        fitted_classifier : SupportVectorMachineClassifier
             The fitted classifier.
 
         Raises
@@ -194,7 +194,7 @@ class SupportVectorMachine(Classifier):
         wrapped_classifier = self._get_sklearn_classifier()
         fit(wrapped_classifier, training_set)
 
-        result = SupportVectorMachine(c=self._c, kernel=self._kernel)
+        result = SupportVectorMachineClassifier(c=self._c, kernel=self._kernel)
         result._wrapped_classifier = wrapped_classifier
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/__init__.py
+++ b/src/safeds/ml/classical/regression/__init__.py
@@ -1,27 +1,27 @@
 """Models for regression tasks."""
 
-from ._ada_boost import AdaBoost
-from ._decision_tree import DecisionTree
-from ._elastic_net_regression import ElasticNetRegression
-from ._gradient_boosting import GradientBoosting
-from ._k_nearest_neighbors import KNearestNeighbors
-from ._lasso_regression import LassoRegression
-from ._linear_regression import LinearRegression
-from ._random_forest import RandomForest
+from ._ada_boost import AdaBoostRegressor
+from ._decision_tree import DecisionTreeRegressor
+from ._elastic_net_regression import ElasticNetRegressor
+from ._gradient_boosting import GradientBoostingRegressor
+from ._k_nearest_neighbors import KNearestNeighborsRegressor
+from ._lasso_regression import LassoRegressor
+from ._linear_regression import LinearRegressionRegressor
+from ._random_forest import RandomForestRegressor
 from ._regressor import Regressor
-from ._ridge_regression import RidgeRegression
-from ._support_vector_machine import SupportVectorMachine
+from ._ridge_regression import RidgeRegressor
+from ._support_vector_machine import SupportVectorMachineRegressor
 
 __all__ = [
-    "AdaBoost",
-    "DecisionTree",
-    "ElasticNetRegression",
-    "GradientBoosting",
-    "KNearestNeighbors",
-    "LassoRegression",
-    "LinearRegression",
-    "RandomForest",
+    "AdaBoostRegressor",
+    "DecisionTreeRegressor",
+    "ElasticNetRegressor",
+    "GradientBoostingRegressor",
+    "KNearestNeighborsRegressor",
+    "LassoRegressor",
+    "LinearRegressionRegressor",
+    "RandomForestRegressor",
     "Regressor",
-    "RidgeRegression",
-    "SupportVectorMachine",
+    "RidgeRegressor",
+    "SupportVectorMachineRegressor",
 ]

--- a/src/safeds/ml/classical/regression/_ada_boost.py
+++ b/src/safeds/ml/classical/regression/_ada_boost.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class AdaBoost(Regressor):
+class AdaBoostRegressor(Regressor):
     """
     Ada Boost regression.
 
@@ -99,7 +99,7 @@ class AdaBoost(Regressor):
         """
         return self._learning_rate
 
-    def fit(self, training_set: TaggedTable) -> AdaBoost:
+    def fit(self, training_set: TaggedTable) -> AdaBoostRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -112,7 +112,7 @@ class AdaBoost(Regressor):
 
         Returns
         -------
-        fitted_regressor : AdaBoost
+        fitted_regressor : AdaBoostRegressor
             The fitted regressor.
 
         Raises
@@ -131,7 +131,7 @@ class AdaBoost(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = AdaBoost(
+        result = AdaBoostRegressor(
             learner=self._learner,
             maximum_number_of_learners=self._maximum_number_of_learners,
             learning_rate=self._learning_rate,

--- a/src/safeds/ml/classical/regression/_decision_tree.py
+++ b/src/safeds/ml/classical/regression/_decision_tree.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class DecisionTree(Regressor):
+class DecisionTreeRegressor(Regressor):
     """Decision tree regression."""
 
     def __init__(self) -> None:
@@ -23,7 +23,7 @@ class DecisionTree(Regressor):
         self._feature_names: list[str] | None = None
         self._target_name: str | None = None
 
-    def fit(self, training_set: TaggedTable) -> DecisionTree:
+    def fit(self, training_set: TaggedTable) -> DecisionTreeRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -36,7 +36,7 @@ class DecisionTree(Regressor):
 
         Returns
         -------
-        fitted_regressor : DecisionTree
+        fitted_regressor : DecisionTreeRegressor
             The fitted regressor.
 
         Raises
@@ -55,7 +55,7 @@ class DecisionTree(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = DecisionTree()
+        result = DecisionTreeRegressor()
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_elastic_net_regression.py
+++ b/src/safeds/ml/classical/regression/_elastic_net_regression.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class ElasticNetRegression(Regressor):
+class ElasticNetRegressor(Regressor):
     """Elastic net regression.
 
     Parameters
@@ -104,7 +104,7 @@ class ElasticNetRegression(Regressor):
         """
         return self._lasso_ratio
 
-    def fit(self, training_set: TaggedTable) -> ElasticNetRegression:
+    def fit(self, training_set: TaggedTable) -> ElasticNetRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -117,7 +117,7 @@ class ElasticNetRegression(Regressor):
 
         Returns
         -------
-        fitted_regressor : ElasticNetRegression
+        fitted_regressor : ElasticNetRegressor
             The fitted regressor.
 
         Raises
@@ -136,7 +136,7 @@ class ElasticNetRegression(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = ElasticNetRegression(alpha=self._alpha, lasso_ratio=self._lasso_ratio)
+        result = ElasticNetRegressor(alpha=self._alpha, lasso_ratio=self._lasso_ratio)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_gradient_boosting.py
+++ b/src/safeds/ml/classical/regression/_gradient_boosting.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class GradientBoosting(Regressor):
+class GradientBoostingRegressor(Regressor):
     """
     Gradient boosting regression.
 
@@ -74,7 +74,7 @@ class GradientBoosting(Regressor):
         """
         return self._learning_rate
 
-    def fit(self, training_set: TaggedTable) -> GradientBoosting:
+    def fit(self, training_set: TaggedTable) -> GradientBoostingRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -87,7 +87,7 @@ class GradientBoosting(Regressor):
 
         Returns
         -------
-        fitted_regressor : GradientBoosting
+        fitted_regressor : GradientBoostingRegressor
             The fitted regressor.
 
         Raises
@@ -106,7 +106,7 @@ class GradientBoosting(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = GradientBoosting(number_of_trees=self._number_of_trees, learning_rate=self._learning_rate)
+        result = GradientBoostingRegressor(number_of_trees=self._number_of_trees, learning_rate=self._learning_rate)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class KNearestNeighbors(Regressor):
+class KNearestNeighborsRegressor(Regressor):
     """
     K-nearest-neighbors regression.
 
@@ -56,7 +56,7 @@ class KNearestNeighbors(Regressor):
         """
         return self._number_of_neighbors
 
-    def fit(self, training_set: TaggedTable) -> KNearestNeighbors:
+    def fit(self, training_set: TaggedTable) -> KNearestNeighborsRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -69,7 +69,7 @@ class KNearestNeighbors(Regressor):
 
         Returns
         -------
-        fitted_regressor : KNearestNeighbors
+        fitted_regressor : KNearestNeighborsRegressor
             The fitted regressor.
 
         Raises
@@ -100,7 +100,7 @@ class KNearestNeighbors(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = KNearestNeighbors(self._number_of_neighbors)
+        result = KNearestNeighborsRegressor(self._number_of_neighbors)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_lasso_regression.py
+++ b/src/safeds/ml/classical/regression/_lasso_regression.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class LassoRegression(Regressor):
+class LassoRegressor(Regressor):
     """Lasso regression.
 
     Parameters
@@ -64,7 +64,7 @@ class LassoRegression(Regressor):
         """
         return self._alpha
 
-    def fit(self, training_set: TaggedTable) -> LassoRegression:
+    def fit(self, training_set: TaggedTable) -> LassoRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -77,7 +77,7 @@ class LassoRegression(Regressor):
 
         Returns
         -------
-        fitted_regressor : LassoRegression
+        fitted_regressor : LassoRegressor
             The fitted regressor.
 
         Raises
@@ -96,7 +96,7 @@ class LassoRegression(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = LassoRegression(alpha=self._alpha)
+        result = LassoRegressor(alpha=self._alpha)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_linear_regression.py
+++ b/src/safeds/ml/classical/regression/_linear_regression.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class LinearRegression(Regressor):
+class LinearRegressionRegressor(Regressor):
     """Linear regression."""
 
     def __init__(self) -> None:
@@ -23,7 +23,7 @@ class LinearRegression(Regressor):
         self._feature_names: list[str] | None = None
         self._target_name: str | None = None
 
-    def fit(self, training_set: TaggedTable) -> LinearRegression:
+    def fit(self, training_set: TaggedTable) -> LinearRegressionRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -36,7 +36,7 @@ class LinearRegression(Regressor):
 
         Returns
         -------
-        fitted_regressor : LinearRegression
+        fitted_regressor : LinearRegressionRegressor
             The fitted regressor.
 
         Raises
@@ -55,7 +55,7 @@ class LinearRegression(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = LinearRegression()
+        result = LinearRegressionRegressor()
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_random_forest.py
+++ b/src/safeds/ml/classical/regression/_random_forest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class RandomForest(Regressor):
+class RandomForestRegressor(Regressor):
     """Random forest regression.
 
     Parameters
@@ -54,7 +54,7 @@ class RandomForest(Regressor):
         """
         return self._number_of_trees
 
-    def fit(self, training_set: TaggedTable) -> RandomForest:
+    def fit(self, training_set: TaggedTable) -> RandomForestRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -67,7 +67,7 @@ class RandomForest(Regressor):
 
         Returns
         -------
-        fitted_regressor : RandomForest
+        fitted_regressor : RandomForestRegressor
             The fitted regressor.
 
         Raises
@@ -86,7 +86,7 @@ class RandomForest(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = RandomForest(number_of_trees=self._number_of_trees)
+        result = RandomForestRegressor(number_of_trees=self._number_of_trees)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_ridge_regression.py
+++ b/src/safeds/ml/classical/regression/_ridge_regression.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from safeds.data.tabular.containers import Table, TaggedTable
 
 
-class RidgeRegression(Regressor):
+class RidgeRegressor(Regressor):
     """
     Ridge regression.
 
@@ -65,7 +65,7 @@ class RidgeRegression(Regressor):
         """
         return self._alpha
 
-    def fit(self, training_set: TaggedTable) -> RidgeRegression:
+    def fit(self, training_set: TaggedTable) -> RidgeRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -78,7 +78,7 @@ class RidgeRegression(Regressor):
 
         Returns
         -------
-        fitted_regressor : RidgeRegression
+        fitted_regressor : RidgeRegressor
             The fitted regressor.
 
         Raises
@@ -97,7 +97,7 @@ class RidgeRegression(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = RidgeRegression(alpha=self._alpha)
+        result = RidgeRegressor(alpha=self._alpha)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/classical/regression/_support_vector_machine.py
+++ b/src/safeds/ml/classical/regression/_support_vector_machine.py
@@ -30,7 +30,7 @@ class SupportVectorMachineKernel(ABC):
         """
 
 
-class SupportVectorMachine(Regressor):
+class SupportVectorMachineRegressor(Regressor):
     """
     Support vector machine.
 
@@ -151,18 +151,18 @@ class SupportVectorMachine(Regressor):
         TypeError
             If the kernel type is invalid.
         """
-        if isinstance(self.kernel, SupportVectorMachine.Kernel.Linear):
+        if isinstance(self.kernel, SupportVectorMachineRegressor.Kernel.Linear):
             return "linear"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.Polynomial):
+        elif isinstance(self.kernel, SupportVectorMachineRegressor.Kernel.Polynomial):
             return "poly"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.Sigmoid):
+        elif isinstance(self.kernel, SupportVectorMachineRegressor.Kernel.Sigmoid):
             return "sigmoid"
-        elif isinstance(self.kernel, SupportVectorMachine.Kernel.RadialBasisFunction):
+        elif isinstance(self.kernel, SupportVectorMachineRegressor.Kernel.RadialBasisFunction):
             return "rbf"
         else:
             raise TypeError("Invalid kernel type.")
 
-    def fit(self, training_set: TaggedTable) -> SupportVectorMachine:
+    def fit(self, training_set: TaggedTable) -> SupportVectorMachineRegressor:
         """
         Create a copy of this regressor and fit it with the given training data.
 
@@ -175,7 +175,7 @@ class SupportVectorMachine(Regressor):
 
         Returns
         -------
-        fitted_regressor : SupportVectorMachine
+        fitted_regressor : SupportVectorMachineRegressor
             The fitted regressor.
 
         Raises
@@ -194,7 +194,7 @@ class SupportVectorMachine(Regressor):
         wrapped_regressor = self._get_sklearn_regressor()
         fit(wrapped_regressor, training_set)
 
-        result = SupportVectorMachine(c=self._c, kernel=self._kernel)
+        result = SupportVectorMachineRegressor(c=self._c, kernel=self._kernel)
         result._wrapped_regressor = wrapped_regressor
         result._feature_names = training_set.features.column_names
         result._target_name = training_set.target.name

--- a/src/safeds/ml/nn/__init__.py
+++ b/src/safeds/ml/nn/__init__.py
@@ -1,10 +1,10 @@
 """Classes for classification tasks."""
 
 from ._fnn_layer import FNNLayer
-from ._model import ClassificationNeuralNetwork, RegressionNeuralNetwork
+from ._model import NeuralNetworkClassifier, NeuralNetworkRegressor
 
 __all__ = [
     "FNNLayer",
-    "ClassificationNeuralNetwork",
-    "RegressionNeuralNetwork",
+    "NeuralNetworkClassifier",
+    "NeuralNetworkRegressor",
 ]

--- a/src/safeds/ml/nn/_model.py
+++ b/src/safeds/ml/nn/_model.py
@@ -10,7 +10,7 @@ from safeds.exceptions import ClosedBound, ModelNotFittedError, OutOfBoundsError
 from safeds.ml.nn._fnn_layer import FNNLayer
 
 
-class RegressionNeuralNetwork:
+class NeuralNetworkRegressor:
     def __init__(self, layers: list):
         self._model = _PytorchModel(layers, is_for_classification=False)
         self._batch_size = 1
@@ -133,7 +133,7 @@ class RegressionNeuralNetwork:
         return self._is_fitted
 
 
-class ClassificationNeuralNetwork:
+class NeuralNetworkClassifier:
     def __init__(self, layers: list[FNNLayer]):
         self._model = _PytorchModel(layers, is_for_classification=True)
         self._batch_size = 1

--- a/tests/safeds/ml/classical/classification/test_ada_boost.py
+++ b/tests/safeds/ml/classical/classification/test_ada_boost.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.classification import AdaBoost
+from safeds.ml.classical.classification import AdaBoostClassifier
 
 
 @pytest.fixture()
@@ -12,24 +12,24 @@ def training_set() -> TaggedTable:
 
 class TestLearner:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        learner = AdaBoost()
-        fitted_model = AdaBoost(learner=learner).fit(training_set)
+        learner = AdaBoostClassifier()
+        fitted_model = AdaBoostClassifier(learner=learner).fit(training_set)
         assert fitted_model.learner == learner
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        learner = AdaBoost()
-        fitted_model = AdaBoost(learner=learner).fit(training_set)
+        learner = AdaBoostClassifier()
+        fitted_model = AdaBoostClassifier(learner=learner).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert isinstance(fitted_model._wrapped_classifier.estimator, type(learner._get_sklearn_classifier()))
 
 
 class TestMaximumNumberOfLearners:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(maximum_number_of_learners=2).fit(training_set)
+        fitted_model = AdaBoostClassifier(maximum_number_of_learners=2).fit(training_set)
         assert fitted_model.maximum_number_of_learners == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(maximum_number_of_learners=2).fit(training_set)
+        fitted_model = AdaBoostClassifier(maximum_number_of_learners=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.n_estimators == 2
 
@@ -39,16 +39,16 @@ class TestMaximumNumberOfLearners:
             OutOfBoundsError,
             match=rf"maximum_number_of_learners \(={maximum_number_of_learners}\) is not inside \[1, \u221e\)\.",
         ):
-            AdaBoost(maximum_number_of_learners=maximum_number_of_learners)
+            AdaBoostClassifier(maximum_number_of_learners=maximum_number_of_learners)
 
 
 class TestLearningRate:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(learning_rate=2).fit(training_set)
+        fitted_model = AdaBoostClassifier(learning_rate=2).fit(training_set)
         assert fitted_model.learning_rate == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(learning_rate=2).fit(training_set)
+        fitted_model = AdaBoostClassifier(learning_rate=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.learning_rate == 2
 
@@ -58,4 +58,4 @@ class TestLearningRate:
             OutOfBoundsError,
             match=rf"learning_rate \(={learning_rate}\) is not inside \(0, \u221e\)\.",
         ):
-            AdaBoost(learning_rate=learning_rate)
+            AdaBoostClassifier(learning_rate=learning_rate)

--- a/tests/safeds/ml/classical/classification/test_classifier.py
+++ b/tests/safeds/ml/classical/classification/test_classifier.py
@@ -262,21 +262,41 @@ class TestIsFitted:
 
 
 class TestHash:
-    @pytest.mark.parametrize(("classifier1", "classifier2"), ([(x, y) for x in classifiers() for y in classifiers() if x.__class__ == y.__class__]), ids=lambda x: x.__class__.__name__)
-    def test_should_return_same_hash_for_equal_classifier(self, classifier1: Classifier, classifier2: Classifier) -> None:
+    @pytest.mark.parametrize(
+        ("classifier1", "classifier2"),
+        ([(x, y) for x in classifiers() for y in classifiers() if x.__class__ == y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_same_hash_for_equal_classifier(
+        self, classifier1: Classifier, classifier2: Classifier,
+    ) -> None:
         assert hash(classifier1) == hash(classifier2)
 
-    @pytest.mark.parametrize(("classifier1", "classifier2"), ([(x, y) for x in classifiers() for y in classifiers() if x.__class__ != y.__class__]), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_unequal_classifier(self, classifier1: Classifier, classifier2: Classifier) -> None:
+    @pytest.mark.parametrize(
+        ("classifier1", "classifier2"),
+        ([(x, y) for x in classifiers() for y in classifiers() if x.__class__ != y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_unequal_classifier(
+        self, classifier1: Classifier, classifier2: Classifier,
+    ) -> None:
         assert hash(classifier1) != hash(classifier2)
 
     @pytest.mark.parametrize("classifier1", classifiers(), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_same_classifier_fit(self, classifier1: Classifier, valid_data: TaggedTable) -> None:
+    def test_should_return_different_hash_for_same_classifier_fit(
+        self, classifier1: Classifier, valid_data: TaggedTable,
+    ) -> None:
         regressor1_fit = classifier1.fit(valid_data)
         assert hash(classifier1) != hash(regressor1_fit)
 
-    @pytest.mark.parametrize(("classifier1", "classifier2"), (list(itertools.product(classifiers(), classifiers()))), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_classifier_fit(self, classifier1: Classifier, classifier2: Classifier, valid_data: TaggedTable) -> None:
+    @pytest.mark.parametrize(
+        ("classifier1", "classifier2"),
+        (list(itertools.product(classifiers(), classifiers()))),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_classifier_fit(
+        self, classifier1: Classifier, classifier2: Classifier, valid_data: TaggedTable,
+    ) -> None:
         classifier1_fit = classifier1.fit(valid_data)
         assert hash(classifier1_fit) != hash(classifier2)
 

--- a/tests/safeds/ml/classical/classification/test_classifier.py
+++ b/tests/safeds/ml/classical/classification/test_classifier.py
@@ -15,14 +15,14 @@ from safeds.exceptions import (
     UntaggedTableError,
 )
 from safeds.ml.classical.classification import (
-    AdaBoost,
+    AdaBoostClassifier,
     Classifier,
-    DecisionTree,
-    GradientBoosting,
-    KNearestNeighbors,
-    LogisticRegression,
-    RandomForest,
-    SupportVectorMachine,
+    DecisionTreeClassifier,
+    GradientBoostingClassifier,
+    KNearestNeighborsClassifier,
+    LogisticRegressionClassifier,
+    RandomForestClassifier,
+    SupportVectorMachineClassifier,
 )
 
 if TYPE_CHECKING:
@@ -43,13 +43,13 @@ def classifiers() -> list[Classifier]:
         The list of classifiers to test.
     """
     return [
-        AdaBoost(),
-        DecisionTree(),
-        GradientBoosting(),
-        KNearestNeighbors(2),
-        LogisticRegression(),
-        RandomForest(),
-        SupportVectorMachine(),
+        AdaBoostClassifier(),
+        DecisionTreeClassifier(),
+        GradientBoostingClassifier(),
+        KNearestNeighborsClassifier(2),
+        LogisticRegressionClassifier(),
+        RandomForestClassifier(),
+        SupportVectorMachineClassifier(),
     ]
 
 

--- a/tests/safeds/ml/classical/classification/test_classifier.py
+++ b/tests/safeds/ml/classical/classification/test_classifier.py
@@ -268,7 +268,9 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_same_hash_for_equal_classifier(
-        self, classifier1: Classifier, classifier2: Classifier,
+        self,
+        classifier1: Classifier,
+        classifier2: Classifier,
     ) -> None:
         assert hash(classifier1) == hash(classifier2)
 
@@ -278,13 +280,17 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_unequal_classifier(
-        self, classifier1: Classifier, classifier2: Classifier,
+        self,
+        classifier1: Classifier,
+        classifier2: Classifier,
     ) -> None:
         assert hash(classifier1) != hash(classifier2)
 
     @pytest.mark.parametrize("classifier1", classifiers(), ids=lambda x: x.__class__.__name__)
     def test_should_return_different_hash_for_same_classifier_fit(
-        self, classifier1: Classifier, valid_data: TaggedTable,
+        self,
+        classifier1: Classifier,
+        valid_data: TaggedTable,
     ) -> None:
         regressor1_fit = classifier1.fit(valid_data)
         assert hash(classifier1) != hash(regressor1_fit)
@@ -295,7 +301,10 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_classifier_fit(
-        self, classifier1: Classifier, classifier2: Classifier, valid_data: TaggedTable,
+        self,
+        classifier1: Classifier,
+        classifier2: Classifier,
+        valid_data: TaggedTable,
     ) -> None:
         classifier1_fit = classifier1.fit(valid_data)
         assert hash(classifier1_fit) != hash(classifier2)

--- a/tests/safeds/ml/classical/classification/test_gradient_boosting.py
+++ b/tests/safeds/ml/classical/classification/test_gradient_boosting.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.classification import GradientBoosting
+from safeds.ml.classical.classification import GradientBoostingClassifier
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfTrees:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(number_of_trees=2).fit(training_set)
+        fitted_model = GradientBoostingClassifier(number_of_trees=2).fit(training_set)
         assert fitted_model.number_of_trees == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(number_of_trees=2).fit(training_set)
+        fitted_model = GradientBoostingClassifier(number_of_trees=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.n_estimators == 2
 
@@ -26,16 +26,16 @@ class TestNumberOfTrees:
             OutOfBoundsError,
             match=rf"number_of_trees \(={number_of_trees}\) is not inside \[1, \u221e\)\.",
         ):
-            GradientBoosting(number_of_trees=number_of_trees)
+            GradientBoostingClassifier(number_of_trees=number_of_trees)
 
 
 class TestLearningRate:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(learning_rate=2).fit(training_set)
+        fitted_model = GradientBoostingClassifier(learning_rate=2).fit(training_set)
         assert fitted_model.learning_rate == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(learning_rate=2).fit(training_set)
+        fitted_model = GradientBoostingClassifier(learning_rate=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.learning_rate == 2
 
@@ -45,4 +45,4 @@ class TestLearningRate:
             OutOfBoundsError,
             match=rf"learning_rate \(={learning_rate}\) is not inside \(0, \u221e\)\.",
         ):
-            GradientBoosting(learning_rate=learning_rate)
+            GradientBoostingClassifier(learning_rate=learning_rate)

--- a/tests/safeds/ml/classical/classification/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classical/classification/test_k_nearest_neighbors.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.classification import KNearestNeighbors
+from safeds.ml.classical.classification import KNearestNeighborsClassifier
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfNeighbors:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = KNearestNeighbors(number_of_neighbors=2).fit(training_set)
+        fitted_model = KNearestNeighborsClassifier(number_of_neighbors=2).fit(training_set)
         assert fitted_model.number_of_neighbors == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = KNearestNeighbors(number_of_neighbors=2).fit(training_set)
+        fitted_model = KNearestNeighborsClassifier(number_of_neighbors=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.n_neighbors == 2
 
@@ -26,8 +26,8 @@ class TestNumberOfNeighbors:
             OutOfBoundsError,
             match=rf"number_of_neighbors \(={number_of_neighbors}\) is not inside \[1, \u221e\)\.",
         ):
-            KNearestNeighbors(number_of_neighbors=number_of_neighbors)
+            KNearestNeighborsClassifier(number_of_neighbors=number_of_neighbors)
 
     def test_should_raise_if_greater_than_sample_size(self, training_set: TaggedTable) -> None:
         with pytest.raises(ValueError, match="has to be less than or equal to the sample size"):
-            KNearestNeighbors(number_of_neighbors=5).fit(training_set)
+            KNearestNeighborsClassifier(number_of_neighbors=5).fit(training_set)

--- a/tests/safeds/ml/classical/classification/test_random_forest.py
+++ b/tests/safeds/ml/classical/classification/test_random_forest.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.classification import RandomForest
+from safeds.ml.classical.classification import RandomForestClassifier
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfTrees:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = RandomForest(number_of_trees=2).fit(training_set)
+        fitted_model = RandomForestClassifier(number_of_trees=2).fit(training_set)
         assert fitted_model.number_of_trees == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = RandomForest(number_of_trees=2).fit(training_set)
+        fitted_model = RandomForestClassifier(number_of_trees=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.n_estimators == 2
 
@@ -26,4 +26,4 @@ class TestNumberOfTrees:
             OutOfBoundsError,
             match=rf"number_of_trees \(={number_of_trees}\) is not inside \[1, \u221e\)\.",
         ):
-            RandomForest(number_of_trees=number_of_trees)
+            RandomForestClassifier(number_of_trees=number_of_trees)

--- a/tests/safeds/ml/classical/classification/test_support_vector_machine.py
+++ b/tests/safeds/ml/classical/classification/test_support_vector_machine.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.classification import SupportVectorMachine
+from safeds.ml.classical.classification import SupportVectorMachineClassifier
 
 
 @pytest.fixture()
@@ -12,75 +12,75 @@ def training_set() -> TaggedTable:
 
 class TestC:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = SupportVectorMachine(c=2).fit(training_set=training_set)
+        fitted_model = SupportVectorMachineClassifier(c=2).fit(training_set=training_set)
         assert fitted_model.c == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = SupportVectorMachine(c=2).fit(training_set)
+        fitted_model = SupportVectorMachineClassifier(c=2).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
         assert fitted_model._wrapped_classifier.C == 2
 
     @pytest.mark.parametrize("c", [-1.0, 0.0], ids=["minus_one", "zero"])
     def test_should_raise_if_less_than_or_equal_to_0(self, c: float) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"c \(={c}\) is not inside \(0, \u221e\)\."):
-            SupportVectorMachine(c=c)
+            SupportVectorMachineClassifier(c=c)
 
 
 class TestKernel:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        kernel = SupportVectorMachine.Kernel.Linear()
-        fitted_model = SupportVectorMachine(c=2, kernel=kernel).fit(training_set=training_set)
-        assert isinstance(fitted_model.kernel, SupportVectorMachine.Kernel.Linear)
+        kernel = SupportVectorMachineClassifier.Kernel.Linear()
+        fitted_model = SupportVectorMachineClassifier(c=2, kernel=kernel).fit(training_set=training_set)
+        assert isinstance(fitted_model.kernel, SupportVectorMachineClassifier.Kernel.Linear)
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        kernel = SupportVectorMachine.Kernel.Linear()
-        fitted_model = SupportVectorMachine(c=2, kernel=kernel).fit(training_set)
+        kernel = SupportVectorMachineClassifier.Kernel.Linear()
+        fitted_model = SupportVectorMachineClassifier(c=2, kernel=kernel).fit(training_set)
         assert fitted_model._wrapped_classifier is not None
-        assert isinstance(fitted_model.kernel, SupportVectorMachine.Kernel.Linear)
+        assert isinstance(fitted_model.kernel, SupportVectorMachineClassifier.Kernel.Linear)
 
     def test_should_get_sklearn_kernel_linear(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Linear())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Linear)
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Linear())
+        assert isinstance(svm.kernel, SupportVectorMachineClassifier.Kernel.Linear)
         linear_kernel = svm.kernel._get_sklearn_kernel()
         assert linear_kernel == "linear"
 
     @pytest.mark.parametrize("degree", [-1, 0], ids=["minus_one", "zero"])
     def test_should_raise_if_degree_less_than_1(self, degree: int) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"degree \(={degree}\) is not inside \[1, \u221e\)\."):
-            SupportVectorMachine.Kernel.Polynomial(degree=degree)
+            SupportVectorMachineClassifier.Kernel.Polynomial(degree=degree)
 
     def test_should_get_sklearn_kernel_polynomial(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Polynomial(degree=2))
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Polynomial)
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Polynomial(degree=2))
+        assert isinstance(svm.kernel, SupportVectorMachineClassifier.Kernel.Polynomial)
         poly_kernel = svm.kernel._get_sklearn_kernel()
         assert poly_kernel == "poly"
 
     def test_should_get_sklearn_kernel_sigmoid(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Sigmoid())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Sigmoid)
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Sigmoid())
+        assert isinstance(svm.kernel, SupportVectorMachineClassifier.Kernel.Sigmoid)
         sigmoid_kernel = svm.kernel._get_sklearn_kernel()
         assert sigmoid_kernel == "sigmoid"
 
     def test_should_get_sklearn_kernel_rbf(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.RadialBasisFunction())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.RadialBasisFunction)
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.RadialBasisFunction())
+        assert isinstance(svm.kernel, SupportVectorMachineClassifier.Kernel.RadialBasisFunction)
         rbf_kernel = svm.kernel._get_sklearn_kernel()
         assert rbf_kernel == "rbf"
 
     def test_should_get_kernel_name(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Linear())
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Linear())
         assert svm._get_kernel_name() == "linear"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Polynomial(degree=2))
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Polynomial(degree=2))
         assert svm._get_kernel_name() == "poly"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Sigmoid())
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.Sigmoid())
         assert svm._get_kernel_name() == "sigmoid"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.RadialBasisFunction())
+        svm = SupportVectorMachineClassifier(c=2, kernel=SupportVectorMachineClassifier.Kernel.RadialBasisFunction())
         assert svm._get_kernel_name() == "rbf"
 
     def test_should_get_kernel_name_invalid_kernel_type(self) -> None:
-        svm = SupportVectorMachine(c=2)
+        svm = SupportVectorMachineClassifier(c=2)
         with pytest.raises(TypeError, match="Invalid kernel type."):
             svm._get_kernel_name()

--- a/tests/safeds/ml/classical/regression/test_ada_boost.py
+++ b/tests/safeds/ml/classical/regression/test_ada_boost.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import AdaBoost
+from safeds.ml.classical.regression import AdaBoostRegressor
 
 
 @pytest.fixture()
@@ -12,24 +12,24 @@ def training_set() -> TaggedTable:
 
 class TestLearner:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        learner = AdaBoost()
-        fitted_model = AdaBoost(learner=learner).fit(training_set)
+        learner = AdaBoostRegressor()
+        fitted_model = AdaBoostRegressor(learner=learner).fit(training_set)
         assert fitted_model.learner == learner
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        learner = AdaBoost()
-        fitted_model = AdaBoost(learner=learner).fit(training_set)
+        learner = AdaBoostRegressor()
+        fitted_model = AdaBoostRegressor(learner=learner).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert isinstance(fitted_model._wrapped_regressor.estimator, type(learner._get_sklearn_regressor()))
 
 
 class TestMaximumNumberOfLearners:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(maximum_number_of_learners=2).fit(training_set)
+        fitted_model = AdaBoostRegressor(maximum_number_of_learners=2).fit(training_set)
         assert fitted_model.maximum_number_of_learners == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(maximum_number_of_learners=2).fit(training_set)
+        fitted_model = AdaBoostRegressor(maximum_number_of_learners=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.n_estimators == 2
 
@@ -39,16 +39,16 @@ class TestMaximumNumberOfLearners:
             OutOfBoundsError,
             match=rf"maximum_number_of_learners \(={maximum_number_of_learners}\) is not inside \[1, \u221e\)\.",
         ):
-            AdaBoost(maximum_number_of_learners=maximum_number_of_learners)
+            AdaBoostRegressor(maximum_number_of_learners=maximum_number_of_learners)
 
 
 class TestLearningRate:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(learning_rate=2).fit(training_set)
+        fitted_model = AdaBoostRegressor(learning_rate=2).fit(training_set)
         assert fitted_model.learning_rate == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = AdaBoost(learning_rate=2).fit(training_set)
+        fitted_model = AdaBoostRegressor(learning_rate=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.learning_rate == 2
 
@@ -58,4 +58,4 @@ class TestLearningRate:
             OutOfBoundsError,
             match=rf"learning_rate \(={learning_rate}\) is not inside \(0, \u221e\)\.",
         ):
-            AdaBoost(learning_rate=learning_rate)
+            AdaBoostRegressor(learning_rate=learning_rate)

--- a/tests/safeds/ml/classical/regression/test_elastic_net_regression.py
+++ b/tests/safeds/ml/classical/regression/test_elastic_net_regression.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import ElasticNetRegression
+from safeds.ml.classical.regression import ElasticNetRegressor
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestAlpha:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = ElasticNetRegression(alpha=1).fit(training_set)
+        fitted_model = ElasticNetRegressor(alpha=1).fit(training_set)
         assert fitted_model.alpha == 1
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = ElasticNetRegression(alpha=1).fit(training_set)
+        fitted_model = ElasticNetRegressor(alpha=1).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.alpha == 1
 
@@ -26,7 +26,7 @@ class TestAlpha:
             OutOfBoundsError,
             match=rf"alpha \(={alpha}\) is not inside \[0, \u221e\)\.",
         ):
-            ElasticNetRegression(alpha=alpha)
+            ElasticNetRegressor(alpha=alpha)
 
     def test_should_warn_if_equal_to_0(self) -> None:
         with pytest.warns(
@@ -36,16 +36,16 @@ class TestAlpha:
                 "should use LinearRegression instead for better numerical stability."
             ),
         ):
-            ElasticNetRegression(alpha=0)
+            ElasticNetRegressor(alpha=0)
 
 
 class TestLassoRatio:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = ElasticNetRegression(lasso_ratio=0.3).fit(training_set)
+        fitted_model = ElasticNetRegressor(lasso_ratio=0.3).fit(training_set)
         assert fitted_model.lasso_ratio == 0.3
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = ElasticNetRegression(lasso_ratio=0.3).fit(training_set)
+        fitted_model = ElasticNetRegressor(lasso_ratio=0.3).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.l1_ratio == 0.3
 
@@ -55,7 +55,7 @@ class TestLassoRatio:
             OutOfBoundsError,
             match=rf"lasso_ratio \(={lasso_ratio}\) is not inside \[0, 1\]\.",
         ):
-            ElasticNetRegression(lasso_ratio=lasso_ratio)
+            ElasticNetRegressor(lasso_ratio=lasso_ratio)
 
     def test_should_warn_if_0(self) -> None:
         with pytest.warns(
@@ -65,7 +65,7 @@ class TestLassoRatio:
                 " Use RidgeRegression instead for better numerical stability."
             ),
         ):
-            ElasticNetRegression(lasso_ratio=0)
+            ElasticNetRegressor(lasso_ratio=0)
 
     def test_should_warn_if_1(self) -> None:
         with pytest.warns(
@@ -75,4 +75,4 @@ class TestLassoRatio:
                 " Use LassoRegression instead for better numerical stability."
             ),
         ):
-            ElasticNetRegression(lasso_ratio=1)
+            ElasticNetRegressor(lasso_ratio=1)

--- a/tests/safeds/ml/classical/regression/test_gradient_boosting.py
+++ b/tests/safeds/ml/classical/regression/test_gradient_boosting.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import GradientBoosting
+from safeds.ml.classical.regression import GradientBoostingRegressor
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfTrees:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(number_of_trees=2).fit(training_set)
+        fitted_model = GradientBoostingRegressor(number_of_trees=2).fit(training_set)
         assert fitted_model.number_of_trees == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(number_of_trees=2).fit(training_set)
+        fitted_model = GradientBoostingRegressor(number_of_trees=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.n_estimators == 2
 
@@ -26,16 +26,16 @@ class TestNumberOfTrees:
             OutOfBoundsError,
             match=rf"number_of_trees \(={number_of_trees}\) is not inside \[1, \u221e\)\.",
         ):
-            GradientBoosting(number_of_trees=number_of_trees)
+            GradientBoostingRegressor(number_of_trees=number_of_trees)
 
 
 class TestLearningRate:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(learning_rate=2).fit(training_set)
+        fitted_model = GradientBoostingRegressor(learning_rate=2).fit(training_set)
         assert fitted_model.learning_rate == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = GradientBoosting(learning_rate=2).fit(training_set)
+        fitted_model = GradientBoostingRegressor(learning_rate=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.learning_rate == 2
 
@@ -45,4 +45,4 @@ class TestLearningRate:
             OutOfBoundsError,
             match=rf"learning_rate \(={learning_rate}\) is not inside \(0, \u221e\)\.",
         ):
-            GradientBoosting(learning_rate=learning_rate)
+            GradientBoostingRegressor(learning_rate=learning_rate)

--- a/tests/safeds/ml/classical/regression/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classical/regression/test_k_nearest_neighbors.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import KNearestNeighbors
+from safeds.ml.classical.regression import KNearestNeighborsRegressor
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfNeighbors:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = KNearestNeighbors(number_of_neighbors=2).fit(training_set)
+        fitted_model = KNearestNeighborsRegressor(number_of_neighbors=2).fit(training_set)
         assert fitted_model.number_of_neighbors == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = KNearestNeighbors(number_of_neighbors=2).fit(training_set)
+        fitted_model = KNearestNeighborsRegressor(number_of_neighbors=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.n_neighbors == 2
 
@@ -26,8 +26,8 @@ class TestNumberOfNeighbors:
             OutOfBoundsError,
             match=rf"number_of_neighbors \(={number_of_neighbors}\) is not inside \[1, \u221e\)\.",
         ):
-            KNearestNeighbors(number_of_neighbors=number_of_neighbors)
+            KNearestNeighborsRegressor(number_of_neighbors=number_of_neighbors)
 
     def test_should_raise_if_greater_than_sample_size(self, training_set: TaggedTable) -> None:
         with pytest.raises(ValueError, match="has to be less than or equal to the sample size"):
-            KNearestNeighbors(number_of_neighbors=5).fit(training_set)
+            KNearestNeighborsRegressor(number_of_neighbors=5).fit(training_set)

--- a/tests/safeds/ml/classical/regression/test_lasso_regression.py
+++ b/tests/safeds/ml/classical/regression/test_lasso_regression.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import LassoRegression
+from safeds.ml.classical.regression import LassoRegressor
 
 
 @pytest.fixture()
@@ -12,18 +12,18 @@ def training_set() -> TaggedTable:
 
 class TestAlpha:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = LassoRegression(alpha=1).fit(training_set)
+        fitted_model = LassoRegressor(alpha=1).fit(training_set)
         assert fitted_model.alpha == 1
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = LassoRegression(alpha=1).fit(training_set)
+        fitted_model = LassoRegressor(alpha=1).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.alpha == 1
 
     @pytest.mark.parametrize("alpha", [-0.5], ids=["minus_zero_point_5"])
     def test_should_raise_if_less_than_0(self, alpha: float) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"alpha \(={alpha}\) is not inside \[0, \u221e\)\."):
-            LassoRegression(alpha=alpha)
+            LassoRegressor(alpha=alpha)
 
     def test_should_warn_if_equal_to_0(self) -> None:
         with pytest.warns(
@@ -33,4 +33,4 @@ class TestAlpha:
                 "should use LinearRegression instead for better numerical stability."
             ),
         ):
-            LassoRegression(alpha=0)
+            LassoRegressor(alpha=0)

--- a/tests/safeds/ml/classical/regression/test_random_forest.py
+++ b/tests/safeds/ml/classical/regression/test_random_forest.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import RandomForest
+from safeds.ml.classical.regression import RandomForestRegressor
 
 
 @pytest.fixture()
@@ -12,11 +12,11 @@ def training_set() -> TaggedTable:
 
 class TestNumberOfTrees:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = RandomForest(number_of_trees=2).fit(training_set)
+        fitted_model = RandomForestRegressor(number_of_trees=2).fit(training_set)
         assert fitted_model.number_of_trees == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = RandomForest(number_of_trees=2).fit(training_set)
+        fitted_model = RandomForestRegressor(number_of_trees=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.n_estimators == 2
 
@@ -26,4 +26,4 @@ class TestNumberOfTrees:
             OutOfBoundsError,
             match=rf"number_of_trees \(={number_of_trees}\) is not inside \[1, \u221e\)\.",
         ):
-            RandomForest(number_of_trees=number_of_trees)
+            RandomForestRegressor(number_of_trees=number_of_trees)

--- a/tests/safeds/ml/classical/regression/test_regressor.py
+++ b/tests/safeds/ml/classical/regression/test_regressor.py
@@ -287,13 +287,17 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_unequal_regressor(
-        self, regressor1: Regressor, regressor2: Regressor,
+        self,
+        regressor1: Regressor,
+        regressor2: Regressor,
     ) -> None:
         assert hash(regressor1) != hash(regressor2)
 
     @pytest.mark.parametrize("regressor1", regressors(), ids=lambda x: x.__class__.__name__)
     def test_should_return_different_hash_for_same_regressor_fit(
-        self, regressor1: Regressor, valid_data: TaggedTable,
+        self,
+        regressor1: Regressor,
+        valid_data: TaggedTable,
     ) -> None:
         regressor1_fit = regressor1.fit(valid_data)
         assert hash(regressor1) != hash(regressor1_fit)
@@ -304,7 +308,10 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_regressor_fit(
-        self, regressor1: Regressor, regressor2: Regressor, valid_data: TaggedTable,
+        self,
+        regressor1: Regressor,
+        regressor2: Regressor,
+        valid_data: TaggedTable,
     ) -> None:
         regressor1_fit = regressor1.fit(valid_data)
         assert hash(regressor1_fit) != hash(regressor2)

--- a/tests/safeds/ml/classical/regression/test_regressor.py
+++ b/tests/safeds/ml/classical/regression/test_regressor.py
@@ -17,17 +17,17 @@ from safeds.exceptions import (
     UntaggedTableError,
 )
 from safeds.ml.classical.regression import (
-    AdaBoost,
-    DecisionTree,
-    ElasticNetRegression,
-    GradientBoosting,
-    KNearestNeighbors,
-    LassoRegression,
-    LinearRegression,
-    RandomForest,
+    AdaBoostRegressor,
+    DecisionTreeRegressor,
+    ElasticNetRegressor,
+    GradientBoostingRegressor,
+    KNearestNeighborsRegressor,
+    LassoRegressor,
+    LinearRegressionRegressor,
+    RandomForestRegressor,
     Regressor,
-    RidgeRegression,
-    SupportVectorMachine,
+    RidgeRegressor,
+    SupportVectorMachineRegressor,
 )
 
 # noinspection PyProtectedMember
@@ -51,16 +51,16 @@ def regressors() -> list[Regressor]:
         The list of regressors to test.
     """
     return [
-        AdaBoost(),
-        DecisionTree(),
-        ElasticNetRegression(),
-        GradientBoosting(),
-        KNearestNeighbors(2),
-        LassoRegression(),
-        LinearRegression(),
-        RandomForest(),
-        RidgeRegression(),
-        SupportVectorMachine(),
+        AdaBoostRegressor(),
+        DecisionTreeRegressor(),
+        ElasticNetRegressor(),
+        GradientBoostingRegressor(),
+        KNearestNeighborsRegressor(2),
+        LassoRegressor(),
+        LinearRegressionRegressor(),
+        RandomForestRegressor(),
+        RidgeRegressor(),
+        SupportVectorMachineRegressor(),
     ]
 
 

--- a/tests/safeds/ml/classical/regression/test_regressor.py
+++ b/tests/safeds/ml/classical/regression/test_regressor.py
@@ -273,21 +273,39 @@ class TestIsFitted:
 
 
 class TestHash:
-    @pytest.mark.parametrize(("regressor1", "regressor2"), ([(x, y) for x in regressors() for y in regressors() if x.__class__ == y.__class__]), ids=lambda x: x.__class__.__name__)
+    @pytest.mark.parametrize(
+        ("regressor1", "regressor2"),
+        ([(x, y) for x in regressors() for y in regressors() if x.__class__ == y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
     def test_should_return_same_hash_for_equal_regressor(self, regressor1: Regressor, regressor2: Regressor) -> None:
         assert hash(regressor1) == hash(regressor2)
 
-    @pytest.mark.parametrize(("regressor1", "regressor2"), ([(x, y) for x in regressors() for y in regressors() if x.__class__ != y.__class__]), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_unequal_regressor(self, regressor1: Regressor, regressor2: Regressor) -> None:
+    @pytest.mark.parametrize(
+        ("regressor1", "regressor2"),
+        ([(x, y) for x in regressors() for y in regressors() if x.__class__ != y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_unequal_regressor(
+        self, regressor1: Regressor, regressor2: Regressor,
+    ) -> None:
         assert hash(regressor1) != hash(regressor2)
 
     @pytest.mark.parametrize("regressor1", regressors(), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_same_regressor_fit(self, regressor1: Regressor, valid_data: TaggedTable) -> None:
+    def test_should_return_different_hash_for_same_regressor_fit(
+        self, regressor1: Regressor, valid_data: TaggedTable,
+    ) -> None:
         regressor1_fit = regressor1.fit(valid_data)
         assert hash(regressor1) != hash(regressor1_fit)
 
-    @pytest.mark.parametrize(("regressor1", "regressor2"), (list(itertools.product(regressors(), regressors()))), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_regressor_fit(self, regressor1: Regressor, regressor2: Regressor, valid_data: TaggedTable) -> None:
+    @pytest.mark.parametrize(
+        ("regressor1", "regressor2"),
+        (list(itertools.product(regressors(), regressors()))),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_regressor_fit(
+        self, regressor1: Regressor, regressor2: Regressor, valid_data: TaggedTable,
+    ) -> None:
         regressor1_fit = regressor1.fit(valid_data)
         assert hash(regressor1_fit) != hash(regressor2)
 

--- a/tests/safeds/ml/classical/regression/test_ridge_regression.py
+++ b/tests/safeds/ml/classical/regression/test_ridge_regression.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import RidgeRegression
+from safeds.ml.classical.regression import RidgeRegressor
 
 
 @pytest.fixture()
@@ -12,18 +12,18 @@ def training_set() -> TaggedTable:
 
 class TestAlpha:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = RidgeRegression(alpha=1).fit(training_set)
+        fitted_model = RidgeRegressor(alpha=1).fit(training_set)
         assert fitted_model.alpha == 1
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = RidgeRegression(alpha=1).fit(training_set)
+        fitted_model = RidgeRegressor(alpha=1).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.alpha == 1
 
     @pytest.mark.parametrize("alpha", [-0.5], ids=["minus_zero_point_5"])
     def test_should_raise_if_less_than_0(self, alpha: float) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"alpha \(={alpha}\) is not inside \[0, \u221e\)\."):
-            RidgeRegression(alpha=alpha)
+            RidgeRegressor(alpha=alpha)
 
     def test_should_warn_if_equal_to_0(self) -> None:
         with pytest.warns(
@@ -33,4 +33,4 @@ class TestAlpha:
                 "should use LinearRegression instead for better numerical stability."
             ),
         ):
-            RidgeRegression(alpha=0)
+            RidgeRegressor(alpha=0)

--- a/tests/safeds/ml/classical/regression/test_support_vector_machine.py
+++ b/tests/safeds/ml/classical/regression/test_support_vector_machine.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import OutOfBoundsError
-from safeds.ml.classical.regression import SupportVectorMachine
+from safeds.ml.classical.regression import SupportVectorMachineRegressor
 
 
 @pytest.fixture()
@@ -12,75 +12,75 @@ def training_set() -> TaggedTable:
 
 class TestC:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        fitted_model = SupportVectorMachine(c=2).fit(training_set=training_set)
+        fitted_model = SupportVectorMachineRegressor(c=2).fit(training_set=training_set)
         assert fitted_model.c == 2
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        fitted_model = SupportVectorMachine(c=2).fit(training_set)
+        fitted_model = SupportVectorMachineRegressor(c=2).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
         assert fitted_model._wrapped_regressor.C == 2
 
     @pytest.mark.parametrize("c", [-1.0, 0.0], ids=["minus_one", "zero"])
     def test_should_raise_if_less_than_or_equal_to_0(self, c: float) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"c \(={c}\) is not inside \(0, \u221e\)\."):
-            SupportVectorMachine(c=c)
+            SupportVectorMachineRegressor(c=c)
 
 
 class TestKernel:
     def test_should_be_passed_to_fitted_model(self, training_set: TaggedTable) -> None:
-        kernel = SupportVectorMachine.Kernel.Linear()
-        fitted_model = SupportVectorMachine(c=2, kernel=kernel).fit(training_set=training_set)
-        assert isinstance(fitted_model.kernel, SupportVectorMachine.Kernel.Linear)
+        kernel = SupportVectorMachineRegressor.Kernel.Linear()
+        fitted_model = SupportVectorMachineRegressor(c=2, kernel=kernel).fit(training_set=training_set)
+        assert isinstance(fitted_model.kernel, SupportVectorMachineRegressor.Kernel.Linear)
 
     def test_should_be_passed_to_sklearn(self, training_set: TaggedTable) -> None:
-        kernel = SupportVectorMachine.Kernel.Linear()
-        fitted_model = SupportVectorMachine(c=2, kernel=kernel).fit(training_set)
+        kernel = SupportVectorMachineRegressor.Kernel.Linear()
+        fitted_model = SupportVectorMachineRegressor(c=2, kernel=kernel).fit(training_set)
         assert fitted_model._wrapped_regressor is not None
-        assert isinstance(fitted_model.kernel, SupportVectorMachine.Kernel.Linear)
+        assert isinstance(fitted_model.kernel, SupportVectorMachineRegressor.Kernel.Linear)
 
     def test_should_get_sklearn_kernel_linear(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Linear())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Linear)
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Linear())
+        assert isinstance(svm.kernel, SupportVectorMachineRegressor.Kernel.Linear)
         linear_kernel = svm.kernel._get_sklearn_kernel()
         assert linear_kernel == "linear"
 
     @pytest.mark.parametrize("degree", [-1, 0], ids=["minus_one", "zero"])
     def test_should_raise_if_degree_less_than_1(self, degree: int) -> None:
         with pytest.raises(OutOfBoundsError, match=rf"degree \(={degree}\) is not inside \[1, \u221e\)\."):
-            SupportVectorMachine.Kernel.Polynomial(degree=degree)
+            SupportVectorMachineRegressor.Kernel.Polynomial(degree=degree)
 
     def test_should_get_sklearn_kernel_polynomial(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Polynomial(degree=2))
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Polynomial)
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Polynomial(degree=2))
+        assert isinstance(svm.kernel, SupportVectorMachineRegressor.Kernel.Polynomial)
         poly_kernel = svm.kernel._get_sklearn_kernel()
         assert poly_kernel == "poly"
 
     def test_should_get_sklearn_kernel_sigmoid(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Sigmoid())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.Sigmoid)
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Sigmoid())
+        assert isinstance(svm.kernel, SupportVectorMachineRegressor.Kernel.Sigmoid)
         sigmoid_kernel = svm.kernel._get_sklearn_kernel()
         assert sigmoid_kernel == "sigmoid"
 
     def test_should_get_sklearn_kernel_rbf(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.RadialBasisFunction())
-        assert isinstance(svm.kernel, SupportVectorMachine.Kernel.RadialBasisFunction)
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.RadialBasisFunction())
+        assert isinstance(svm.kernel, SupportVectorMachineRegressor.Kernel.RadialBasisFunction)
         rbf_kernel = svm.kernel._get_sklearn_kernel()
         assert rbf_kernel == "rbf"
 
     def test_should_get_kernel_name(self) -> None:
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Linear())
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Linear())
         assert svm._get_kernel_name() == "linear"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Polynomial(degree=2))
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Polynomial(degree=2))
         assert svm._get_kernel_name() == "poly"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.Sigmoid())
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.Sigmoid())
         assert svm._get_kernel_name() == "sigmoid"
 
-        svm = SupportVectorMachine(c=2, kernel=SupportVectorMachine.Kernel.RadialBasisFunction())
+        svm = SupportVectorMachineRegressor(c=2, kernel=SupportVectorMachineRegressor.Kernel.RadialBasisFunction())
         assert svm._get_kernel_name() == "rbf"
 
     def test_should_get_kernel_name_invalid_kernel_type(self) -> None:
-        svm = SupportVectorMachine(c=2)
+        svm = SupportVectorMachineRegressor(c=2)
         with pytest.raises(TypeError, match="Invalid kernel type."):
             svm._get_kernel_name()

--- a/tests/safeds/ml/classical/test_util_sklearn.py
+++ b/tests/safeds/ml/classical/test_util_sklearn.py
@@ -5,14 +5,14 @@ import pytest
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classical._util_sklearn import fit, predict
-from safeds.ml.classical.regression import LinearRegression
+from safeds.ml.classical.regression import LinearRegressionRegressor
 
 
 def test_predict_should_not_warn_about_feature_names() -> None:
     """See https://github.com/Safe-DS/Library/issues/51."""
     training_set = Table({"a": [1, 2, 3], "b": [2, 4, 6]}).tag_columns(target_name="b")
 
-    model = LinearRegression()
+    model = LinearRegressionRegressor()
     fitted_model = model.fit(training_set)
 
     test_set = Table({"a": [4, 5, 6]})

--- a/tests/safeds/ml/nn/test_model.py
+++ b/tests/safeds/ml/nn/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import ModelNotFittedError, OutOfBoundsError
-from safeds.ml.nn import ClassificationNeuralNetwork, FNNLayer, RegressionNeuralNetwork
+from safeds.ml.nn import NeuralNetworkClassifier, FNNLayer, NeuralNetworkRegressor
 
 
 class TestClassificationModel:
@@ -17,7 +17,7 @@ class TestClassificationModel:
             OutOfBoundsError,
             match=rf"epoch_size \(={epoch_size}\) is not inside \[1, \u221e\)\.",
         ):
-            ClassificationNeuralNetwork([FNNLayer(1, 1)]).fit(
+            NeuralNetworkClassifier([FNNLayer(1, 1)]).fit(
                 Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
                 epoch_size=epoch_size,
             )
@@ -34,21 +34,21 @@ class TestClassificationModel:
             OutOfBoundsError,
             match=rf"batch_size \(={batch_size}\) is not inside \[1, \u221e\)\.",
         ):
-            ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).fit(
+            NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1)]).fit(
                 Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
                 batch_size=batch_size,
             )
 
     def test_should_raise_if_fit_function_returns_wrong_datatype(self) -> None:
-        fitted_model = ClassificationNeuralNetwork(
+        fitted_model = NeuralNetworkClassifier(
             [FNNLayer(input_size=1, output_size=8), FNNLayer(output_size=1)],
         ).fit(
             Table.from_dict({"a": [1], "b": [0]}).tag_columns("a"),
         )
-        assert isinstance(fitted_model, ClassificationNeuralNetwork)
+        assert isinstance(fitted_model, NeuralNetworkClassifier)
 
     def test_should_raise_if_predict_function_returns_wrong_datatype(self) -> None:
-        fitted_model = ClassificationNeuralNetwork(
+        fitted_model = NeuralNetworkClassifier(
             [FNNLayer(input_size=1, output_size=8), FNNLayer(output_size=1)],
         ).fit(
             Table.from_dict({"a": [1, 0], "b": [0, 1]}).tag_columns("a"),
@@ -57,7 +57,7 @@ class TestClassificationModel:
         assert isinstance(predictions, TaggedTable)
 
     def test_should_raise_if_predict_function_returns_wrong_datatype_for_multiclass_classification(self) -> None:
-        fitted_model = ClassificationNeuralNetwork(
+        fitted_model = NeuralNetworkClassifier(
             [FNNLayer(input_size=1, output_size=8), FNNLayer(output_size=3)],
         ).fit(
             Table.from_dict({"a": [0, 1, 2], "b": [0, 15, 51]}).tag_columns("a"),
@@ -67,12 +67,12 @@ class TestClassificationModel:
 
     def test_should_raise_if_model_has_not_been_fitted(self) -> None:
         with pytest.raises(ModelNotFittedError, match="The model has not been fitted yet."):
-            ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).predict(
+            NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1)]).predict(
                 Table.from_dict({"a": [1]}),
             )
 
     def test_should_raise_if_is_fitted_is_set_correctly_for_binary_classification(self) -> None:
-        model = ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1)])
         assert not model.is_fitted
         model = model.fit(
             Table.from_dict({"a": [1], "b": [0]}).tag_columns("a"),
@@ -80,7 +80,7 @@ class TestClassificationModel:
         assert model.is_fitted
 
     def test_should_raise_if_is_fitted_is_set_correctly_for_multiclass_classification(self) -> None:
-        model = ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1), FNNLayer(output_size=3)])
+        model = NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1), FNNLayer(output_size=3)])
         assert not model.is_fitted
         model = model.fit(
             Table.from_dict({"a": [1, 0, 2], "b": [0, 15, 5]}).tag_columns("a"),
@@ -88,7 +88,7 @@ class TestClassificationModel:
         assert model.is_fitted
 
     def test_should_raise_if_fit_doesnt_batch_callback(self) -> None:
-        model = ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1)])
 
         class Test:
             self.was_called = False
@@ -106,7 +106,7 @@ class TestClassificationModel:
         assert obj.callback_was_called() is True
 
     def test_should_raise_if_fit_doesnt_epoch_callback(self) -> None:
-        model = ClassificationNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkClassifier([FNNLayer(input_size=1, output_size=1)])
 
         class Test:
             self.was_called = False
@@ -137,7 +137,7 @@ class TestRegressionModel:
             OutOfBoundsError,
             match=rf"epoch_size \(={epoch_size}\) is not inside \[1, \u221e\)\.",
         ):
-            RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).fit(
+            NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)]).fit(
                 Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
                 epoch_size=epoch_size,
             )
@@ -154,19 +154,19 @@ class TestRegressionModel:
             OutOfBoundsError,
             match=rf"batch_size \(={batch_size}\) is not inside \[1, \u221e\)\.",
         ):
-            RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).fit(
+            NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)]).fit(
                 Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
                 batch_size=batch_size,
             )
 
     def test_should_raise_if_fit_function_returns_wrong_datatype(self) -> None:
-        fitted_model = RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).fit(
+        fitted_model = NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)]).fit(
             Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
         )
-        assert isinstance(fitted_model, RegressionNeuralNetwork)
+        assert isinstance(fitted_model, NeuralNetworkRegressor)
 
     def test_should_raise_if_predict_function_returns_wrong_datatype(self) -> None:
-        fitted_model = RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).fit(
+        fitted_model = NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)]).fit(
             Table.from_dict({"a": [1], "b": [2]}).tag_columns("a"),
         )
         predictions = fitted_model.predict(Table.from_dict({"b": [1]}))
@@ -174,12 +174,12 @@ class TestRegressionModel:
 
     def test_should_raise_if_model_has_not_been_fitted(self) -> None:
         with pytest.raises(ModelNotFittedError, match="The model has not been fitted yet."):
-            RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)]).predict(
+            NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)]).predict(
                 Table.from_dict({"a": [1]}),
             )
 
     def test_should_raise_if_is_fitted_is_set_correctly(self) -> None:
-        model = RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)])
         assert not model.is_fitted
         model = model.fit(
             Table.from_dict({"a": [1], "b": [0]}).tag_columns("a"),
@@ -187,7 +187,7 @@ class TestRegressionModel:
         assert model.is_fitted
 
     def test_should_raise_if_fit_doesnt_batch_callback(self) -> None:
-        model = RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)])
 
         class Test:
             self.was_called = False
@@ -205,7 +205,7 @@ class TestRegressionModel:
         assert obj.callback_was_called() is True
 
     def test_should_raise_if_fit_doesnt_epoch_callback(self) -> None:
-        model = RegressionNeuralNetwork([FNNLayer(input_size=1, output_size=1)])
+        model = NeuralNetworkRegressor([FNNLayer(input_size=1, output_size=1)])
 
         class Test:
             self.was_called = False

--- a/tests/safeds/ml/nn/test_model.py
+++ b/tests/safeds/ml/nn/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import ModelNotFittedError, OutOfBoundsError
-from safeds.ml.nn import NeuralNetworkClassifier, FNNLayer, NeuralNetworkRegressor
+from safeds.ml.nn import FNNLayer, NeuralNetworkClassifier, NeuralNetworkRegressor
 
 
 class TestClassificationModel:


### PR DESCRIPTION
### Summary of Changes

Add the suffix `Classifier` to all models for classification and `Regressor` to all models for regression. While being longer, this naming has many advantages:

* Better **readability**: Several models have variants for classification and regressions. Previously, both had the same name, so to understand which one was used in the code, imports had to be checked.
* Better **auto-completion**: Now users can simply write `Classifier` or `Regressor` to get a list of all suitable models.
* Better **understandability**: Now it's obvious, that logistic regression is used for classification.