### PR TITLE
docs: fix typo in docstring of `Image.flip_horizontally`

### DIFF
--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -345,7 +345,7 @@ class Image:
 
     def flip_horizontally(self) -> Image:
         """
-        Return a new `Ìmage` that is flipped horizontally (vertical axis, flips left-right and vice versa).
+        Return a new `Image` that is flipped horizontally (vertical axis, flips left-right and vice versa).
 
         The original image is not modified.
 


### PR DESCRIPTION
Closes #583

### Summary of Changes

Replace `Ìmage` with `Image` in docstring of `Image.flip_horizontally`.