### PR TITLE
docs: fix Mathjax startup

### DIFF
--- a/docs/javascript/mathjax.js
+++ b/docs/javascript/mathjax.js
@@ -12,5 +12,8 @@ window.MathJax = {
 };
 
 document$.subscribe(() => {
+    MathJax.startup.output.clearCache();
+    MathJax.typesetClear();
+    MathJax.texReset();
     MathJax.typesetPromise();
 });


### PR DESCRIPTION
### Summary of Changes

Update the MathJax config script, so math blocks get rendered properly already the first time a page is visited.
