### PR TITLE
feat: rename `number_of_column` in `Row` to `number_of_columns`

### DIFF
--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -345,20 +345,20 @@ class Row(Mapping[str, Any]):
         return self._schema.column_names
 
     @property
-    def number_of_column(self) -> int:
+    def number_of_columns(self) -> int:
         """
         Return the number of columns in this row.
 
         Returns
         -------
-        number_of_column : int
+        number_of_columns : int
             The number of columns.
 
         Examples
         --------
         >>> from safeds.data.tabular.containers import Row
         >>> row = Row({"a": 1, "b": 2})
-        >>> row.number_of_column
+        >>> row.number_of_columns
         2
         """
         return self._data.shape[1]

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -202,7 +202,6 @@ class TestHash:
     @pytest.mark.parametrize(
         ("row1", "row2"),
         [
-
             (Row({"col1": 0}), Row({"col1": 1})),
             (Row({"col1": 0}), Row({"col2": 0})),
             (Row({"col1": 0}), Row({"col1": "a"})),

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -346,7 +346,7 @@ class TestNumberOfColumns:
         ],
     )
     def test_should_return_the_number_of_columns(self, row: Row, expected: int) -> None:
-        assert row.number_of_column == expected
+        assert row.number_of_columns == expected
 
 
 class TestGetValue:


### PR DESCRIPTION
Closes #646

### Summary of Changes

Rename `number_of_column` in the `Row` class to `number_of_columns`. This fixes a typo.