### PR TITLE
feat: rename `group_rows_by` in `Table` to `group_rows`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1153,7 +1153,7 @@ class Table:
 
     _T = TypeVar("_T")
 
-    def group_rows_by(self, key_selector: Callable[[Row], _T]) -> dict[_T, Table]:
+    def group_rows(self, key_selector: Callable[[Row], _T]) -> dict[_T, Table]:
         """
         Return a dictionary with copies of the output tables as values and the keys from the key_selector.
 

--- a/tests/safeds/data/tabular/containers/_table/test_group_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_group_rows.py
@@ -31,5 +31,5 @@ from safeds.data.tabular.containers import Table
     ids=["select by row1", "different types in column", "empty table", "table with no rows"],
 )
 def test_should_group_rows(table: Table, selector: Callable, expected: dict) -> None:
-    out = table.group_rows_by(selector)
+    out = table.group_rows(selector)
     assert out == expected


### PR DESCRIPTION
Closes #611

### Summary of Changes

Rename `group_rows_by` in the `Table` class to `group_rows`. This is more in line with similar methods that expect a callback like `sort_rows` or `filter_rows`.
