### PR TITLE
docs: remove type hints from parameters & results in docstrings

### DIFF
--- a/src/safeds/_utils/_hashing.py
+++ b/src/safeds/_utils/_hashing.py
@@ -10,12 +10,12 @@ def _structural_hash(*value: Any) -> int:
 
     Parameters
     ----------
-    value
+    value:
         Variable amount of values to hash
 
     Returns
     -------
-    hash
+    hash:
         Deterministic hash value
     """
     import xxhash
@@ -29,12 +29,12 @@ def _value_to_bytes(value: Any) -> bytes:
 
     Parameters
     ----------
-    value
+    value:
         Object to convert to a byte representation for deterministic structural hashing
 
     Returns
     -------
-    bytes
+    bytes:
         Byte representation of the provided value
     """
     if value is None:

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -21,7 +21,7 @@ class Row(Mapping[str, Any]):
 
     Parameters
     ----------
-    data : Mapping[str, Any] | None
+    data:
         The data. If None, an empty row is created.
 
     Examples
@@ -41,12 +41,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        data : dict[str, Any]
+        data:
             The data.
 
         Returns
         -------
-        row : Row
+        row:
             The created row.
 
         Examples
@@ -63,14 +63,14 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        data : pd.DataFrame
+        data:
             The data.
-        schema : Schema | None
+        schema:
             The schema. If None, the schema is inferred from the data.
 
         Returns
         -------
-        row : Row
+        row:
             The created row.
 
         Raises
@@ -110,7 +110,7 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        data : Mapping[str, Any] | None
+        data:
             The data. If None, an empty row is created.
 
         Examples
@@ -138,12 +138,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        obj : Any
+        obj:
             The object.
 
         Returns
         -------
-        has_column : bool
+        has_column:
             True, if the row contains the object as key, False otherwise.
 
         Examples
@@ -164,12 +164,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        other : Any
+        other:
             The other object.
 
         Returns
         -------
-        equal : bool
+        equal:
             True if the other object is an identical row. False if the other object is a different row. NotImplemented
             if the other object is not a row.
 
@@ -197,12 +197,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The column name.
 
         Returns
         -------
-        value : Any
+        value:
             The column value.
 
         Raises
@@ -236,7 +236,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        iterator : Iterator[Any]
+        iterator:
             The iterator.
 
         Examples
@@ -254,7 +254,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        number_of_columns : int
+        number_of_columns:
             The number of columns.
 
         Examples
@@ -272,7 +272,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        representation : str
+        representation:
             The string representation.
 
         Examples
@@ -301,7 +301,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        representation : str
+        representation:
             The string representation.
 
         Examples
@@ -332,7 +332,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        column_names : list[str]
+        column_names:
             The column names.
 
         Examples
@@ -351,7 +351,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        number_of_columns : int
+        number_of_columns:
             The number of columns.
 
         Examples
@@ -370,7 +370,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        schema : Schema
+        schema:
             The schema.
 
         Examples
@@ -391,12 +391,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The column name.
 
         Returns
         -------
-        value : Any
+        value:
             The column value.
 
         Raises
@@ -422,12 +422,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The column name.
 
         Returns
         -------
-        has_column : bool
+        has_column:
             True, if the row contains the column, False otherwise.
 
         Examples
@@ -448,12 +448,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The column name.
 
         Returns
         -------
-        type : ColumnType
+        type:
             The type of the column.
 
         Raises
@@ -492,12 +492,12 @@ class Row(Mapping[str, Any]):
 
         Parameters
         ----------
-        comparator : Callable[[tuple, tuple], int]
+        comparator:
             The function used to compare two tuples of (ColumnName, Value).
 
         Returns
         -------
-        new_row : Row
+        new_row:
             A new row with sorted columns.
         """
         sorted_row_dict = dict(sorted(self.to_dict().items(), key=functools.cmp_to_key(comparator)))
@@ -513,7 +513,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        data : dict[str, Any]
+        data:
             Dictionary representation of the row.
 
         Examples
@@ -531,7 +531,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        output : str
+        output:
             The generated HTML.
 
         Examples
@@ -552,7 +552,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        output : str
+        output:
             The generated HTML.
         """
         return self._data.to_html(max_rows=1, max_cols=self._data.shape[1], notebook=True)

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -55,7 +55,7 @@ class Table:
 
     Parameters
     ----------
-    data : Mapping[str, Sequence[Any]] | None
+    data:
         The data. If None, an empty table is created.
 
     Raises
@@ -80,12 +80,12 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the CSV file.
 
         Returns
         -------
-        table : Table
+        table:
             The table created from the CSV file.
 
         Raises
@@ -126,12 +126,12 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the Excel file.
 
         Returns
         -------
-        table : Table
+        table:
             The table created from the Excel file.
 
         Raises
@@ -170,12 +170,12 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the JSON file.
 
         Returns
         -------
-        table : Table
+        table:
             The table created from the JSON file.
 
         Raises
@@ -215,12 +215,12 @@ class Table:
 
         Parameters
         ----------
-        data : dict[str, list[Any]]
+        data:
             The data.
 
         Returns
         -------
-        table : Table
+        table:
             The generated table.
 
         Raises
@@ -246,12 +246,12 @@ class Table:
 
         Parameters
         ----------
-        columns : list[Column]
+        columns:
             The columns to be combined. They need to have the same size.
 
         Returns
         -------
-        table : Table
+        table:
             The generated table.
 
         Raises
@@ -297,12 +297,12 @@ class Table:
 
         Parameters
         ----------
-        rows : list[Row]
+        rows:
             The rows to be combined. They need to have a matching schema.
 
         Returns
         -------
-        table : Table
+        table:
             The generated table.
 
         Raises
@@ -350,14 +350,14 @@ class Table:
 
         Parameters
         ----------
-        data : pd.DataFrame
+        data:
             The data.
-        schema : Schema | None
+        schema:
             The schema. If None, the schema is inferred from the data.
 
         Returns
         -------
-        table : Table
+        table:
             The created table.
 
         Examples
@@ -395,7 +395,7 @@ class Table:
 
         Parameters
         ----------
-        data : Mapping[str, Sequence[Any]] | None
+        data:
             The data. If None, an empty table is created.
 
         Raises
@@ -441,7 +441,8 @@ class Table:
 
         Returns
         -------
-        'True' if contents are equal, 'False' otherwise.
+        equals:
+            'True' if contents are equal, 'False' otherwise.
 
         Examples
         --------
@@ -486,7 +487,8 @@ class Table:
 
         Returns
         -------
-        A string representation of the table in only one line.
+        representation:
+            A string representation of the table in only one line.
 
         Examples
         --------
@@ -528,7 +530,7 @@ class Table:
 
         Returns
         -------
-        column_names : list[str]
+        column_names:
             The list of the column names.
 
         Examples
@@ -547,7 +549,7 @@ class Table:
 
         Returns
         -------
-        number_of_columns : int
+        number_of_columns:
             The number of columns.
 
         Examples
@@ -566,7 +568,7 @@ class Table:
 
         Returns
         -------
-        number_of_rows : int
+        number_of_rows:
             The number of rows.
 
         Examples
@@ -585,7 +587,7 @@ class Table:
 
         Returns
         -------
-        schema : Schema
+        schema:
             The schema.
 
         Examples
@@ -614,12 +616,12 @@ class Table:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name of the column.
 
         Returns
         -------
-        column : Column
+        column:
             The column.
 
         Raises
@@ -651,12 +653,12 @@ class Table:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name of the column.
 
         Returns
         -------
-        contains : bool
+        contains:
             True if the column exists.
 
         Examples
@@ -678,12 +680,12 @@ class Table:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name of the column to be queried.
 
         Returns
         -------
-        type : ColumnType
+        type:
             The type of the column.
 
         Raises
@@ -706,12 +708,12 @@ class Table:
 
         Parameters
         ----------
-        index : int
+        index:
             The index.
 
         Returns
         -------
-        row : Row
+        row:
             The row of the table at the index.
 
         Raises
@@ -740,12 +742,12 @@ class Table:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name to compare the Table's column names to.
 
         Returns
         -------
-        similar_columns: list[str]
+        similar_columns:
             A list of all column names in the Table that are similar or equal to the given column name.
         """
         import Levenshtein
@@ -776,7 +778,7 @@ class Table:
 
         Returns
         -------
-        result : Table
+        result:
             The table with statistics.
 
         Examples
@@ -881,7 +883,7 @@ class Table:
 
         Returns
         -------
-        table: Table
+        table:
             The table, as an instance of the Table class.
         """
         return self
@@ -894,7 +896,7 @@ class Table:
 
         Returns
         -------
-        result : Table
+        result:
             The table with the column attached.
 
         Raises
@@ -933,12 +935,12 @@ class Table:
 
         Parameters
         ----------
-        columns : list[Column] or Table
+        columns:
             The columns to be added.
 
         Returns
         -------
-        result: Table
+        result:
             A new table combining the original table and the given columns.
 
         Raises
@@ -986,12 +988,12 @@ class Table:
 
         Parameters
         ----------
-        row : Row
+        row:
             The row to be added.
 
         Returns
         -------
-        table : Table
+        table:
             A new table with the added row at the end.
 
         Raises
@@ -1048,12 +1050,12 @@ class Table:
 
         Parameters
         ----------
-        rows : list[Row] or Table
+        rows:
             The rows to be added.
 
         Returns
         -------
-        result : Table
+        result:
             A new table which combines the original table and the given rows.
 
         Raises
@@ -1126,12 +1128,12 @@ class Table:
 
         Parameters
         ----------
-        query : lambda function
+        query:
             A Callable that is applied to all rows.
 
         Returns
         -------
-        table : Table
+        table:
             A table containing only the rows filtered by the query.
 
         Examples
@@ -1161,12 +1163,12 @@ class Table:
 
         Parameters
         ----------
-        key_selector : Callable[[Row], _T]
+        key_selector:
             A Callable that is applied to all rows and returns the key of the group.
 
         Returns
         -------
-        dictionary : dict
+        dictionary:
             A dictionary containing the new tables as values and the selected keys as keys.
         """
         dictionary: dict[Table._T, Table] = {}
@@ -1187,12 +1189,12 @@ class Table:
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             A list containing only the columns to be kept.
 
         Returns
         -------
-        table : Table
+        table:
             A table containing only the given column(s).
 
         Raises
@@ -1232,12 +1234,12 @@ class Table:
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             A list containing all columns to be dropped.
 
         Returns
         -------
-        table : Table
+        table:
             A table without the given columns.
 
         Raises
@@ -1283,7 +1285,7 @@ class Table:
 
         Returns
         -------
-        table : Table
+        table:
             A table without the columns that contain missing values.
 
         Raises
@@ -1312,7 +1314,7 @@ class Table:
 
         Returns
         -------
-        table : Table
+        table:
             A table without the columns that contain non-numerical values.
 
         Raises
@@ -1339,7 +1341,7 @@ class Table:
 
         Returns
         -------
-        result : Table
+        result:
             The table with the duplicate rows removed.
 
         Examples
@@ -1363,7 +1365,7 @@ class Table:
 
         Returns
         -------
-        table : Table
+        table:
             A table without the rows that contain missing values.
 
         Examples
@@ -1389,7 +1391,7 @@ class Table:
 
         Returns
         -------
-        new_table : Table
+        new_table:
             A new table without rows containing outliers.
 
         Examples
@@ -1431,14 +1433,14 @@ class Table:
 
         Parameters
         ----------
-        old_name : str
+        old_name:
             The old name of the target column.
-        new_name : str
+        new_name:
             The new name of the target column.
 
         Returns
         -------
-        table : Table
+        table:
             The Table with the renamed column.
 
         Raises
@@ -1478,15 +1480,15 @@ class Table:
 
         Parameters
         ----------
-        old_column_name : str
+        old_column_name:
             The name of the column to be replaced.
 
-        new_columns : list[Column]
+        new_columns:
             The list of new columns replacing the old column.
 
         Returns
         -------
-        result : Table
+        result:
             A table with the old column replaced by the new columns.
 
         Raises
@@ -1536,7 +1538,7 @@ class Table:
 
         Returns
         -------
-        result : Table
+        result:
             The shuffled Table.
 
         Examples
@@ -1568,11 +1570,11 @@ class Table:
 
         Parameters
         ----------
-        start : int | None
+        start:
             The first index of the range to be copied into a new table, None by default.
-        end : int | None
+        end:
             The last index of the range to be copied into a new table, None by default.
-        step : int
+        step:
             The step size used to iterate through the table, 1 by default.
 
         Returns
@@ -1630,12 +1632,12 @@ class Table:
 
         Parameters
         ----------
-        comparator : Callable[[Column, Column], int]
+        comparator:
             The function used to compare two columns.
 
         Returns
         -------
-        new_table : Table
+        new_table:
             A new table with sorted columns.
 
         Examples
@@ -1672,12 +1674,12 @@ class Table:
 
         Parameters
         ----------
-        comparator : Callable[[Row, Row], int]
+        comparator:
             The function used to compare two rows.
 
         Returns
         -------
-        new_table : Table
+        new_table:
             A new table with sorted rows.
 
         Examples
@@ -1712,12 +1714,12 @@ class Table:
 
         Parameters
         ----------
-        percentage_in_first : float
+        percentage_in_first:
             The desired size of the first table in percentage to the given table; must be between 0 and 1.
 
         Returns
         -------
-        result : (Table, Table)
+        result:
             A tuple containing the two resulting tables. The first table has the specified size, the second table
             contains the rest of the data.
 
@@ -1758,14 +1760,14 @@ class Table:
 
         Parameters
         ----------
-        target_name : str
+        target_name:
             Name of the target column.
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target column are used.
 
         Returns
         -------
-        tagged_table : TaggedTable
+        tagged_table:
             A new tagged table with the given target and feature names.
 
         Raises
@@ -1793,16 +1795,16 @@ class Table:
 
         Parameters
         ----------
-        target_name : str
+        target_name:
             Name of the target column.
-        time_name : str
+        time_name:
             Name of the time column.
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target and time columns are used.
 
         Returns
         -------
-        time_series : TimeSeries
+        time_series:
             A new time series with the given target, time and feature names.
 
         Raises
@@ -1830,7 +1832,7 @@ class Table:
 
         Returns
         -------
-        result : Table
+        result:
             The table with the transformed column.
 
         Raises
@@ -1863,12 +1865,12 @@ class Table:
 
         Parameters
         ----------
-        transformer : TableTransformer
+        transformer:
             The transformer which transforms the given table.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -1901,12 +1903,12 @@ class Table:
 
         Parameters
         ----------
-        transformer : InvertibleTableTransformer
+        transformer:
             A transformer that was fitted with columns, which are all present in the table.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises
@@ -1945,7 +1947,7 @@ class Table:
 
         Returns
         -------
-        plot: Image
+        plot:
             The plot as an image.
 
         Examples
@@ -2010,14 +2012,14 @@ class Table:
 
         Parameters
         ----------
-        x_column_name : str
+        x_column_name:
             The column name of the column to be plotted on the x-Axis.
-        y_column_name : str
+        y_column_name:
             The column name of the column to be plotted on the y-Axis.
 
         Returns
         -------
-        plot: Image
+        plot:
             The plot as an image.
 
         Raises
@@ -2071,14 +2073,14 @@ class Table:
 
         Parameters
         ----------
-        x_column_name : str
+        x_column_name:
             The column name of the column to be plotted on the x-Axis.
-        y_column_name : str
+        y_column_name:
             The column name of the column to be plotted on the y-Axis.
 
         Returns
         -------
-        plot: Image
+        plot:
             The plot as an image.
 
         Raises
@@ -2132,7 +2134,7 @@ class Table:
 
         Returns
         -------
-        plot: Image
+        plot:
             The plot as an image.
 
         Raises
@@ -2260,7 +2262,7 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the output file.
 
         Raises
@@ -2292,7 +2294,7 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the output file.
 
         Raises
@@ -2331,7 +2333,7 @@ class Table:
 
         Parameters
         ----------
-        path : str | Path
+        path:
             The path to the output file.
 
         Raises
@@ -2359,7 +2361,7 @@ class Table:
 
         Returns
         -------
-        data : dict[str, list[Any]]
+        data:
             Dictionary representation of the table.
 
         Examples
@@ -2380,7 +2382,7 @@ class Table:
 
         Returns
         -------
-        output : str
+        output:
             The generated HTML.
 
         Examples
@@ -2397,7 +2399,7 @@ class Table:
 
         Returns
         -------
-        columns : list[Columns]
+        columns:
             List of columns.
 
         Examples
@@ -2415,7 +2417,7 @@ class Table:
 
         Returns
         -------
-        rows : list[Row]
+        rows:
             List of rows.
 
         Examples
@@ -2451,7 +2453,7 @@ class Table:
 
         Returns
         -------
-        output : str
+        output:
             The generated HTML.
         """
         return self._data.to_html(max_rows=self._data.shape[0], max_cols=self._data.shape[1], notebook=True)
@@ -2474,14 +2476,14 @@ class Table:
 
         Parameters
         ----------
-        nan_as_null : bool
+        nan_as_null:
             Whether to replace missing values in the data with `NaN`.
-        allow_copy : bool
+        allow_copy:
             Whether memory may be copied to create the DataFrame exchange object.
 
         Returns
         -------
-        dataframe
+        dataframe:
             A DataFrame object that conforms to the dataframe interchange protocol.
         """
         if not allow_copy:
@@ -2499,12 +2501,12 @@ class Table:
 
         Parameters
         ----------
-        batch_size
+        batch_size:
             The size of data batches that should be loaded at one time.
 
         Returns
         -------
-        result :
+        result:
             The DataLoader.
 
         """

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -2179,7 +2179,7 @@ class Table:
         buffer.seek(0)
         return Image.from_bytes(buffer.read())
 
-    def plot_histograms(self, *, number_of_bins : int = 10) -> Image:
+    def plot_histograms(self, *, number_of_bins: int = 10) -> Image:
         """
         Plot a histogram for every column.
 
@@ -2210,7 +2210,7 @@ class Table:
         fig, axs = plt.subplots(n_rows, n_cols, tight_layout=True, figsize=(n_cols * 3, n_rows * 3))
 
         col_names = self.column_names
-        for col_name, ax in zip(col_names, axs.flatten() if not one_col else [axs]):
+        for col_name, ax in zip(col_names, axs.flatten() if not one_col else [axs], strict=False):
             np_col = np.array(self.get_column(col_name))
             bins = min(number_of_bins, len(pd.unique(np_col)))
 
@@ -2228,16 +2228,16 @@ class Table:
 
                     bars = np.array([])
                     for i in range(len(hist)):
-                        bars = np.append(bars, f'{round(bin_edges[i], 2)}-{round(bin_edges[i+1], 2)}')
+                        bars = np.append(bars, f"{round(bin_edges[i], 2)}-{round(bin_edges[i+1], 2)}")
 
-                    ax.bar(bars, hist, edgecolor='black')
+                    ax.bar(bars, hist, edgecolor="black")
                     ax.set_xticks(np.arange(len(hist)), bars, rotation=45, horizontalalignment="right")
                     continue
 
             np_col = np_col.astype(str)
             unique_values = np.unique(np_col)
             hist = np.array([np.sum(np_col == value) for value in unique_values])
-            ax.bar(unique_values, hist, edgecolor='black')
+            ax.bar(unique_values, hist, edgecolor="black")
             ax.set_xticks(np.arange(len(unique_values)), unique_values, rotation=45, horizontalalignment="right")
 
         for i in range(len(col_names), n_rows * n_cols):

--- a/src/safeds/data/tabular/containers/_tagged_table.py
+++ b/src/safeds/data/tabular/containers/_tagged_table.py
@@ -26,11 +26,11 @@ class TaggedTable(Table):
 
     Parameters
     ----------
-    data : Mapping[str, Sequence[Any]]
+    data:
         The data.
-    target_name : str
+    target_name:
         Name of the target column.
-    feature_names : list[str] | None
+    feature_names:
         Names of the feature columns. If None, all columns except the target column are used.
 
     Raises
@@ -64,16 +64,16 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table.
-        target_name : str
+        target_name:
             Name of the target column.
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target column are used.
 
         Returns
         -------
-        tagged_table : TaggedTable
+        tagged_table:
             The created table.
 
         Raises
@@ -131,11 +131,11 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        data : Mapping[str, Sequence[Any]]
+        data:
             The data.
-        target_name : str
+        target_name:
             Name of the target column.
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target column are used.
 
         Raises
@@ -176,7 +176,8 @@ class TaggedTable(Table):
 
         Returns
         -------
-        'True' if contents and tags are equal, 'False' otherwise.
+        equals:
+            'True' if contents and tags are equal, 'False' otherwise.
         """
         if not isinstance(other, TaggedTable):
             return NotImplemented
@@ -217,7 +218,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        Table
+        features:
             The table containing the feature columns.
         """
         return self._features
@@ -229,7 +230,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        Column
+        target:
             The target column.
         """
         return self._target
@@ -246,12 +247,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        column : Column
+        column:
             The column to be added.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The table with the attached feature column.
 
         Raises
@@ -275,12 +276,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        columns : list[Column] | Table
+        columns:
             The columns to be added as features.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The table with the attached feature columns.
 
         Raises
@@ -309,12 +310,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        self: TaggedTable
+        self:
             The TaggedTable.
 
         Returns
         -------
-        table: Table
+        table:
             The table as an untagged Table, i.e. without the information about which columns are features or target.
 
         """
@@ -328,12 +329,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        column : Column
+        column:
             The column to be added.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The table with the column attached as neither target nor feature column.
 
         Raises
@@ -357,12 +358,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        columns : list[Column] or Table
+        columns:
             The columns to be added.
 
         Returns
         -------
-        result: TaggedTable
+        result:
             A new table combining the original table and the given columns as neither target nor feature columns.
 
         Raises
@@ -386,12 +387,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        row : Row
+        row:
             The row to be added.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A new tagged table with the added row at the end.
 
         Raises
@@ -409,12 +410,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        rows : list[Row] or Table
+        rows:
             The rows to be added.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             A new tagged table which combines the original table and the given rows.
 
         Raises
@@ -432,12 +433,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        query : lambda function
+        query:
             A Callable that is applied to all rows.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             A new tagged table containing only the rows to match the query.
         """
         return TaggedTable._from_table(
@@ -454,12 +455,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             A list containing only the columns to be kept.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A table containing only the given column(s).
 
         Raises
@@ -490,12 +491,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             The names of all columns to be dropped.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A table without the given columns.
 
         Raises
@@ -528,7 +529,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A table without the columns that contain missing values.
 
         Raises
@@ -560,7 +561,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A table without the columns that contain non-numerical values.
 
         Raises
@@ -592,7 +593,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The table with the duplicate rows removed.
         """
         return TaggedTable._from_table(
@@ -609,7 +610,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A table without the rows that contain missing values.
         """
         return TaggedTable._from_table(
@@ -630,7 +631,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        new_table : TaggedTable
+        new_table:
             A new table without rows containing outliers.
         """
         return TaggedTable._from_table(
@@ -647,14 +648,14 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        old_name : str
+        old_name:
             The old name of the target column.
-        new_name : str
+        new_name:
             The new name of the target column.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             The Table with the renamed column.
 
         Raises
@@ -688,14 +689,14 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        old_column_name : str
+        old_column_name:
             The name of the column to be replaced.
-        new_columns : list[Column]
+        new_columns:
             The new columns replacing the old column.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             A table with the old column replaced by the new column.
 
         Raises
@@ -741,7 +742,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The shuffled Table.
         """
         return TaggedTable._from_table(
@@ -763,16 +764,16 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        start : int | None
+        start:
             The first index of the range to be copied into a new table, None by default.
-        end : int | None
+        end:
             The last index of the range to be copied into a new table, None by default.
-        step : int
+        step:
             The step size used to iterate through the table, 1 by default.
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The resulting table.
 
         Raises
@@ -807,12 +808,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        comparator : Callable[[Column, Column], int]
+        comparator:
             The function used to compare two columns.
 
         Returns
         -------
-        new_table : TaggedTable
+        new_table:
             A new table with sorted columns.
         """
         sorted_table = super().sort_columns(comparator)
@@ -840,12 +841,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        comparator : Callable[[Row, Row], int]
+        comparator:
             The function used to compare two rows.
 
         Returns
         -------
-        new_table : TaggedTable
+        new_table:
             A new table with sorted rows.
         """
         return TaggedTable._from_table(
@@ -862,7 +863,7 @@ class TaggedTable(Table):
 
         Returns
         -------
-        result : TaggedTable
+        result:
             The table with the transformed column.
 
         Raises
@@ -884,12 +885,12 @@ class TaggedTable(Table):
 
         Parameters
         ----------
-        batch_size
+        batch_size:
             The size of data batches that should be loaded at one time.
 
         Returns
         -------
-        result :
+        result:
             The DataLoader.
 
         """

--- a/src/safeds/data/tabular/containers/_time_series.py
+++ b/src/safeds/data/tabular/containers/_time_series.py
@@ -41,13 +41,10 @@ class TimeSeries(Table):
         ----------
         path:
             The path to the CSV file.
-
         target_name:
             The name of the target column
-
         time_name:
             The name of the time column
-
         feature_names:
             The name(s) of the column(s)
 
@@ -86,14 +83,14 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        tagged_table: TaggedTable
+        tagged_table:
             The tagged table.
-        time_name: str
+        time_name:
             Name of the time column.
 
         Returns
         -------
-        time_series : TimeSeries
+        time_series:
             the created time series
 
         Raises
@@ -139,18 +136,18 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table.
-        target_name : str
+        target_name:
             Name of the target column.
-        time_name: str
+        time_name:
             Name of the date column.
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target and time columns are used.
 
         Returns
         -------
-        time_series : TimeSeries
+        time_series:
             the created time series
 
         Raises
@@ -215,13 +212,13 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        data : Mapping[str, Sequence[Any]]
+        data:
             The data.
-        target_name : str
+        target_name:
             Name of the target column.
-        time_name : str
+        time_name:
             Name of the time column
-        feature_names : list[str] | None
+        feature_names:
             Names of the feature columns. If None, all columns except the target and time columns are used.
 
         Raises
@@ -277,7 +274,8 @@ class TimeSeries(Table):
 
         Returns
         -------
-        'True' if contents are equal, 'False' otherwise.
+        equals:
+            'True' if contents are equal, 'False' otherwise.
         """
         if not isinstance(other, TimeSeries):
             return NotImplemented
@@ -324,7 +322,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        Column
+        target:
             The target column.
         """
         return self._target
@@ -336,7 +334,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        Table
+        features:
             The table containing the feature columns.
         """
         return self._features
@@ -348,7 +346,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        Column
+        time:
             The time column.
         """
         return self._time
@@ -364,12 +362,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        self: TimeSeries
+        self:
             The Time Series.
 
         Returns
         -------
-        table: Table
+        table:
             The time series as an untagged Table, i.e. without the information about which columns are features, target or time.
 
         """
@@ -383,12 +381,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        column : Column
+        column:
             The column to be added.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The time series with the column attached as neither target nor feature column.
 
         Raises
@@ -412,12 +410,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        column : Column
+        column:
             The column to be added.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The time series with the attached feature column.
 
         Raises
@@ -442,12 +440,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        columns : list[Column] | Table
+        columns:
             The columns to be added as features.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The time series with the attached feature columns.
 
         Raises
@@ -473,12 +471,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        columns : list[Column] or Table
+        columns:
             The columns to be added.
 
         Returns
         -------
-        result: TimeSeries
+        result:
             A new time series combining the original table and the given columns as neither target nor feature columns.
 
         Raises
@@ -503,12 +501,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        row : Row
+        row:
             The row to be added.
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A new time series with the added row at the end.
 
         Raises
@@ -531,12 +529,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        rows : list[Row] or Table
+        rows:
             The rows to be added.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             A new time series which combines the original time series and the given rows.
 
         Raises
@@ -559,12 +557,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        query : lambda function
+        query:
             A Callable that is applied to all rows.
 
         Returns
         -------
-        result: TimeSeries
+        result:
             A time series containing only the rows to match the query.
         """
         return TimeSeries._from_table(
@@ -582,12 +580,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             A list containing the columns to be kept.
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A time series containing only the given column(s).
 
         Raises
@@ -619,12 +617,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        column_names : list[str]
+        column_names:
             The names of all columns to be dropped.
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A time series without the given columns.
 
         Raises
@@ -660,7 +658,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A time series without the columns that contain missing values.
 
         Raises
@@ -695,7 +693,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A time series without the columns that contain non-numerical values.
 
         Raises
@@ -730,7 +728,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The time series with the duplicate rows removed.
         """
         return TimeSeries._from_table(
@@ -748,7 +746,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        table : TimeSeries
+        table:
             A time series without the rows that contain missing values.
         """
         return TimeSeries._from_table(
@@ -770,7 +768,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        new_time_series : TimeSeries
+        new_time_series:
             A new time series without rows containing outliers.
         """
         return TimeSeries._from_table(
@@ -788,14 +786,14 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        old_name : str
+        old_name:
             The old name of the column.
-        new_name : str
+        new_name:
             The new name of the column.
 
         Returns
         -------
-        table : TimeSeries
+        table:
             The time series with the renamed column.
 
         Raises
@@ -828,14 +826,14 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        old_column_name : str
+        old_column_name:
             The name of the column to be replaced.
-        new_columns : list[Column]
+        new_columns:
             The new columns replacing the old column.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             A time series with the old column replaced by the new columns.
 
         Raises
@@ -901,16 +899,16 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        start : int | None
+        start:
             The first index of the range to be copied into a new time series, None by default.
-        end : int | None
+        end:
             The last index of the range to be copied into a new time series, None by default.
-        step : int
+        step:
             The step size used to iterate through the time series, 1 by default.
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The resulting time series.
 
         Raises
@@ -946,12 +944,12 @@ class TimeSeries(Table):
 
         Parameters
         ----------
-        comparator : Callable[[Column, Column], int]
+        comparator:
             The function used to compare two columns.
 
         Returns
         -------
-        new_time_series : TimeSeries
+        new_time_series:
             A new time series with sorted columns.
         """
         sorted_table = super().sort_columns(comparator)
@@ -980,7 +978,7 @@ class TimeSeries(Table):
 
         Returns
         -------
-        result : TimeSeries
+        result:
             The time series with the transformed column.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_discretizer.py
+++ b/src/safeds/data/tabular/transformation/_discretizer.py
@@ -22,7 +22,7 @@ class Discretizer(TableTransformer):
 
     Parameters
     ----------
-    number_of_bins
+    number_of_bins:
         The number of bins to be created.
 
     Raises
@@ -47,14 +47,14 @@ class Discretizer(TableTransformer):
 
         Parameters
         ----------
-        table
+        table:
             The table used to fit the transformer.
-        column_names
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer :
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -104,12 +104,12 @@ class Discretizer(TableTransformer):
 
         Parameters
         ----------
-        table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table :
+        transformed_table:
             The transformed table.
 
         Raises
@@ -160,7 +160,7 @@ class Discretizer(TableTransformer):
 
         Returns
         -------
-        added_columns :
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -179,7 +179,7 @@ class Discretizer(TableTransformer):
 
         Returns
         -------
-        changed_columns :
+        changed_columns:
              The list of (potentially) changed column names, as passed to fit.
 
         Raises
@@ -197,7 +197,7 @@ class Discretizer(TableTransformer):
 
         Returns
         -------
-        removed_columns :
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the Discretizer was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -19,7 +19,7 @@ class Imputer(TableTransformer):
 
     Parameters
     ----------
-    strategy : ImputerStrategy
+    strategy:
         The strategy used to impute missing values. Use the classes nested inside `Imputer.Strategy` to specify it.
 
     Examples
@@ -44,7 +44,7 @@ class Imputer(TableTransformer):
 
             Parameters
             ----------
-            value :
+            value:
                 The given value to impute missing values.
             """
 
@@ -111,7 +111,11 @@ class Imputer(TableTransformer):
                 imputer.strategy = "median"
 
         class Mode(ImputerStrategy):
-            """An imputation strategy for imputing missing data with mode values. The lowest value will be used if there are multiple values with the same highest count."""
+            """
+            An imputation strategy for imputing missing data with mode values.
+
+            The lowest value will be used if there are multiple values with the same highest count.
+            """
 
             def __eq__(self, other: object) -> bool:
                 if not isinstance(other, Imputer.Strategy.Mode):
@@ -141,14 +145,14 @@ class Imputer(TableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -223,12 +227,12 @@ class Imputer(TableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -272,7 +276,7 @@ class Imputer(TableTransformer):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -291,7 +295,7 @@ class Imputer(TableTransformer):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              The list of (potentially) changed column names, as passed to fit.
 
         Raises
@@ -309,7 +313,7 @@ class Imputer(TableTransformer):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the Imputer was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -29,14 +29,14 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -84,12 +84,12 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -126,12 +126,12 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        transformed_table : Table
+        transformed_table:
             The table to be transformed back to the original version.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises
@@ -188,7 +188,7 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -207,7 +207,7 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              The list of (potentially) changed column names, as passed to fit.
 
         Raises
@@ -225,7 +225,7 @@ class LabelEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the LabelEncoder was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -74,14 +74,14 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -159,12 +159,12 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -247,12 +247,12 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Parameters
         ----------
-        transformed_table : Table
+        transformed_table:
             The table to be transformed back to the original version.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises
@@ -354,7 +354,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -373,7 +373,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              The empty list.
 
         Raises
@@ -391,7 +391,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the OneHotEncoder was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_range_scaler.py
+++ b/src/safeds/data/tabular/transformation/_range_scaler.py
@@ -16,9 +16,9 @@ class RangeScaler(InvertibleTableTransformer):
 
     Parameters
     ----------
-    minimum : float
+    minimum:
         The minimum of the new range after the transformation
-    maximum : float
+    maximum:
         The maximum of the new range after the transformation
 
     Raises
@@ -43,14 +43,14 @@ class RangeScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -108,12 +108,12 @@ class RangeScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -169,12 +169,12 @@ class RangeScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        transformed_table : Table
+        transformed_table:
             The table to be transformed back to the original version.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises
@@ -234,7 +234,7 @@ class RangeScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -253,7 +253,7 @@ class RangeScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              The list of (potentially) changed column names, as passed to fit.
 
         Raises
@@ -271,7 +271,7 @@ class RangeScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the RangeScaler was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_standard_scaler.py
+++ b/src/safeds/data/tabular/transformation/_standard_scaler.py
@@ -25,14 +25,14 @@ class StandardScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
 
         Raises
@@ -90,12 +90,12 @@ class StandardScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -151,12 +151,12 @@ class StandardScaler(InvertibleTableTransformer):
 
         Parameters
         ----------
-        transformed_table : Table
+        transformed_table:
             The table to be transformed back to the original version.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises
@@ -216,7 +216,7 @@ class StandardScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -235,7 +235,7 @@ class StandardScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              The list of (potentially) changed column names, as passed to fit.
 
         Raises
@@ -253,7 +253,7 @@ class StandardScaler(InvertibleTableTransformer):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the StandardScaler was fitted on.
 
         Raises

--- a/src/safeds/data/tabular/transformation/_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_table_transformer.py
@@ -35,14 +35,14 @@ class TableTransformer(ABC):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : TableTransformer
+        fitted_transformer:
             The fitted transformer.
         """
 
@@ -55,12 +55,12 @@ class TableTransformer(ABC):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table to which the learned transformation is applied.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
 
         Raises
@@ -76,7 +76,7 @@ class TableTransformer(ABC):
 
         Returns
         -------
-        added_columns : list[str]
+        added_columns:
             A list of names of the added columns, ordered as they will appear in the table.
 
         Raises
@@ -92,7 +92,7 @@ class TableTransformer(ABC):
 
         Returns
         -------
-        changed_columns : list[str]
+        changed_columns:
              A list of names of changed columns, ordered as they appear in the table.
 
         Raises
@@ -108,7 +108,7 @@ class TableTransformer(ABC):
 
         Returns
         -------
-        removed_columns : list[str]
+        removed_columns:
             A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on.
 
         Raises
@@ -130,14 +130,14 @@ class TableTransformer(ABC):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer. The transformer is then applied to this table.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        transformed_table : Table
+        transformed_table:
             The transformed table.
         """
         return self.fit(table, column_names).transform(table)
@@ -153,14 +153,14 @@ class InvertibleTableTransformer(TableTransformer):
 
         Parameters
         ----------
-        table : Table
+        table:
             The table used to fit the transformer.
-        column_names : list[str] | None
+        column_names:
             The list of columns from the table used to fit the transformer. If `None`, all columns are used.
 
         Returns
         -------
-        fitted_transformer : InvertibleTableTransformer
+        fitted_transformer:
             The fitted transformer.
         """
 
@@ -173,12 +173,12 @@ class InvertibleTableTransformer(TableTransformer):
 
         Parameters
         ----------
-        transformed_table : Table
+        transformed_table:
             The table to be transformed back to the original version.
 
         Returns
         -------
-        table : Table
+        table:
             The original table.
 
         Raises

--- a/src/safeds/data/tabular/typing/_column_type.py
+++ b/src/safeds/data/tabular/typing/_column_type.py
@@ -21,7 +21,7 @@ class ColumnType(ABC):
 
         Parameters
         ----------
-        is_nullable
+        is_nullable:
             Whether the columntype is nullable.
         """
 
@@ -32,12 +32,12 @@ class ColumnType(ABC):
 
         Parameters
         ----------
-        data : pd.Series
+        data:
             The data to be checked.
 
         Returns
         -------
-        column_type : ColumnType
+        column_type:
             The ColumnType.
 
         Raises
@@ -98,7 +98,7 @@ class ColumnType(ABC):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
 
@@ -109,7 +109,7 @@ class ColumnType(ABC):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
 
@@ -121,7 +121,7 @@ class Anything(ColumnType):
 
     Parameters
     ----------
-    is_nullable : bool
+    is_nullable:
         Whether the type also allows null values.
     """
 
@@ -142,7 +142,7 @@ class Anything(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return self._is_nullable
@@ -153,7 +153,7 @@ class Anything(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return False
@@ -166,7 +166,7 @@ class Boolean(ColumnType):
 
     Parameters
     ----------
-    is_nullable : bool
+    is_nullable:
         Whether the type also allows null values.
     """
 
@@ -187,7 +187,7 @@ class Boolean(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return self._is_nullable
@@ -198,7 +198,7 @@ class Boolean(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return False
@@ -211,7 +211,7 @@ class RealNumber(ColumnType):
 
     Parameters
     ----------
-    is_nullable : bool
+    is_nullable:
         Whether the type also allows null values.
     """
 
@@ -232,7 +232,7 @@ class RealNumber(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return self._is_nullable
@@ -243,7 +243,7 @@ class RealNumber(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return True
@@ -256,7 +256,7 @@ class Integer(ColumnType):
 
     Parameters
     ----------
-    is_nullable : bool
+    is_nullable:
         Whether the type also allows null values.
     """
 
@@ -277,7 +277,7 @@ class Integer(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return self._is_nullable
@@ -288,7 +288,7 @@ class Integer(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return True
@@ -301,7 +301,7 @@ class String(ColumnType):
 
     Parameters
     ----------
-    is_nullable : bool
+    is_nullable:
         Whether the type also allows null values.
     """
 
@@ -322,7 +322,7 @@ class String(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return self._is_nullable
@@ -333,7 +333,7 @@ class String(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return False
@@ -360,7 +360,7 @@ class Nothing(ColumnType):
 
         Returns
         -------
-        is_nullable : bool
+        is_nullable:
             True if the column is nullable.
         """
         return True
@@ -371,7 +371,7 @@ class Nothing(ColumnType):
 
         Returns
         -------
-        is_numeric : bool
+        is_numeric:
             True if the column is numeric.
         """
         return False

--- a/src/safeds/data/tabular/typing/_imputer_strategy.py
+++ b/src/safeds/data/tabular/typing/_imputer_strategy.py
@@ -23,7 +23,7 @@ class ImputerStrategy(ABC):
 
         Parameters
         ----------
-        imputer: SimpleImputer
+        imputer:
             The imputer to augment.
         """
 

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -20,7 +20,7 @@ class Schema:
 
     Parameters
     ----------
-    schema : dict[str, ColumnType]
+    schema:
         Map from column names to data types.
 
     Examples
@@ -42,12 +42,12 @@ class Schema:
 
         Parameters
         ----------
-        dataframe : pd.DataFrame
+        dataframe:
             The dataframe.
 
         Returns
         -------
-        schema : Schema
+        schema:
             The schema.
         """
         names = dataframe.columns
@@ -90,7 +90,7 @@ class Schema:
 
         Returns
         -------
-        representation : str
+        representation:
             The string representation.
 
         Examples
@@ -123,7 +123,7 @@ class Schema:
 
         Returns
         -------
-        string : str
+        string:
             The string representation.
 
         Examples
@@ -150,7 +150,7 @@ class Schema:
 
         Returns
         -------
-        column_names : list[str]
+        column_names:
             The column names.
 
         Examples
@@ -168,12 +168,12 @@ class Schema:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name of the column.
 
         Returns
         -------
-        contains : bool
+        contains:
             True if the schema contains the column.
 
         Examples
@@ -194,12 +194,12 @@ class Schema:
 
         Parameters
         ----------
-        column_name : str
+        column_name:
             The name of the column.
 
         Returns
         -------
-        type : ColumnType
+        type:
             The type of the column.
 
         Raises
@@ -228,7 +228,7 @@ class Schema:
 
         Returns
         -------
-        data : dict[str, ColumnType]
+        data:
             Dictionary representation of the schema.
 
         Examples
@@ -256,12 +256,12 @@ class Schema:
 
         Parameters
         ----------
-        schemas : list[Schema]
+        schemas:
             the list of schemas you want to merge
 
         Returns
         -------
-        schema : Schema
+        schema:
             the new merged schema
 
         Raises
@@ -313,7 +313,7 @@ class Schema:
 
         Returns
         -------
-        markdown : str
+        markdown:
             The Markdown representation.
         """
         if len(self._schema) == 0:

--- a/src/safeds/exceptions/_data.py
+++ b/src/safeds/exceptions/_data.py
@@ -12,7 +12,7 @@ class UnknownColumnNameError(KeyError):
 
     Parameters
     ----------
-    column_names : list[str]
+    column_names:
         The name of the column that was tried to be accessed.
     """
 
@@ -59,7 +59,7 @@ class DuplicateColumnNameError(Exception):
 
     Parameters
     ----------
-    column_name : str
+    column_name:
         The name of the column that resulted in a duplicate.
     """
 
@@ -73,7 +73,7 @@ class IndexOutOfBoundsError(IndexError):
 
     Parameters
     ----------
-    index : int | list[int] | slice
+    index:
         The wrongly used index.
     """
 
@@ -96,7 +96,7 @@ class DuplicateIndexError(IndexError):
 
     Parameters
     ----------
-    index : int
+    index:
         The wrongly added index.
     """
 
@@ -110,9 +110,9 @@ class ColumnSizeError(Exception):
 
     Parameters
     ----------
-    expected_size : str
+    expected_size:
         The expected size of the column as an expression (e.g. 2, >0, !=0).
-    actual_size : str
+    actual_size:
         The actual size of the column as an expression (e.g. 2, >0, !=0).
     """
 

--- a/src/safeds/exceptions/_generic.py
+++ b/src/safeds/exceptions/_generic.py
@@ -9,13 +9,13 @@ class OutOfBoundsError(ValueError):
 
     Parameters
     ----------
-    actual: float
+    actual:
         The actual value that is outside its expected range.
-    name: str | None
+    name:
         The name of the offending variable.
-    lower_bound: Bound | None
+    lower_bound:
         The lower bound of the expected range. Use None if there is no lower Bound.
-    upper_bound: Bound | None
+    upper_bound:
         The upper bound of the expected range. Use None if there is no upper Bound.
     """
 
@@ -32,13 +32,13 @@ class OutOfBoundsError(ValueError):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that is outside its expected range.
-        name: str | None
+        name:
             The name of the offending variable.
-        lower_bound: Bound | None
+        lower_bound:
             The lower bound of the expected range. Use None if there is no lower Bound.
-        upper_bound: Bound | None
+        upper_bound:
             The upper bound of the expected range. Use None if there is no upper Bound.
 
         Raises
@@ -94,7 +94,7 @@ class Bound(ABC):
 
     Parameters
     ----------
-    value: float
+    value:
         The value of the Bound.
     """
 
@@ -104,7 +104,7 @@ class Bound(ABC):
 
         Parameters
         ----------
-        value: float
+        value:
             The value of the Bound.
 
         Raises
@@ -142,7 +142,7 @@ class Bound(ABC):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
 
@@ -153,7 +153,7 @@ class Bound(ABC):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
 
@@ -164,7 +164,7 @@ class ClosedBound(Bound):
 
     Parameters
     ----------
-    value: float
+    value:
         The value of the Bound.
     """
 
@@ -174,7 +174,7 @@ class ClosedBound(Bound):
 
         Parameters
         ----------
-        value: float
+        value:
             The value of the ClosedBound.
 
         Raises
@@ -200,7 +200,7 @@ class ClosedBound(Bound):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
         return actual >= self.value
@@ -211,7 +211,7 @@ class ClosedBound(Bound):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
         return actual <= self.value
@@ -223,7 +223,7 @@ class OpenBound(Bound):
 
     Parameters
     ----------
-    value: float
+    value:
         The value of the OpenBound.
     """
 
@@ -233,7 +233,7 @@ class OpenBound(Bound):
 
         Parameters
         ----------
-        value: float
+        value:
             The value of the OpenBound.
 
         Raises
@@ -266,7 +266,7 @@ class OpenBound(Bound):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
         return actual > self.value
@@ -277,7 +277,7 @@ class OpenBound(Bound):
 
         Parameters
         ----------
-        actual: float
+        actual:
             The actual value that should be checked for not exceeding the Bound.
         """
         return actual < self.value

--- a/src/safeds/exceptions/_ml.py
+++ b/src/safeds/exceptions/_ml.py
@@ -4,7 +4,7 @@ class DatasetContainsTargetError(ValueError):
 
     Parameters
     ----------
-    target_name: str
+    target_name:
         The name of the target column.
     """
 
@@ -18,7 +18,7 @@ class DatasetMissesFeaturesError(ValueError):
 
     Parameters
     ----------
-    missing_feature_names: list[str]
+    missing_feature_names:
         The names of the missing feature columns.
     """
 
@@ -39,7 +39,7 @@ class LearningError(Exception):
 
     Parameters
     ----------
-    reason: str
+    reason:
         The reason for the error.
     """
 
@@ -60,7 +60,7 @@ class PredictionError(Exception):
 
     Parameters
     ----------
-    reason: str
+    reason:
         The reason for the error.
     """
 

--- a/src/safeds/ml/classical/_util_sklearn.py
+++ b/src/safeds/ml/classical/_util_sklearn.py
@@ -22,9 +22,9 @@ def fit(model: Any, tagged_table: TaggedTable) -> None:
 
     Parameters
     ----------
-    model
+    model:
         Classifier or Regression from scikit-learn.
-    tagged_table : TaggedTable
+    tagged_table:
         The tagged table containing the feature and target vectors.
 
     Raises
@@ -83,18 +83,18 @@ def predict(model: Any, dataset: Table, feature_names: list[str] | None, target_
 
     Parameters
     ----------
-    model
+    model:
         Classifier or regressor from scikit-learn.
-    dataset : Table
+    dataset:
         The dataset containing the features.
-    target_name : str | None
+    target_name:
         The name of the target column.
-    feature_names : list[str] | None
+    feature_names:
         The names of the feature columns.
 
     Returns
     -------
-    table : TaggedTable
+    table:
         A dataset containing the given features and the predicted target.
 
     Raises

--- a/src/safeds/ml/classical/classification/_ada_boost.py
+++ b/src/safeds/ml/classical/classification/_ada_boost.py
@@ -21,12 +21,12 @@ class AdaBoostClassifier(Classifier):
 
     Parameters
     ----------
-    learner: Classifier | None
+    learner:
         The learner from which the boosted ensemble is built.
-    maximum_number_of_learners: int
+    maximum_number_of_learners:
         The maximum number of learners at which boosting is terminated. In case of perfect fit, the learning procedure
         is stopped early. Has to be greater than 0.
-    learning_rate : float
+    learning_rate:
         Weight applied to each classifier at each boosting iteration. A higher learning rate increases the contribution
         of each classifier. Has to be greater than 0.
 
@@ -79,7 +79,7 @@ class AdaBoostClassifier(Classifier):
 
         Returns
         -------
-        result: Classifier | None
+        result:
             The base learner.
         """
         return self._learner
@@ -91,7 +91,7 @@ class AdaBoostClassifier(Classifier):
 
         Returns
         -------
-        result: int
+        result:
             The maximum number of learners.
         """
         return self._maximum_number_of_learners
@@ -103,7 +103,7 @@ class AdaBoostClassifier(Classifier):
 
         Returns
         -------
-        result: float
+        result:
             The learning rate.
         """
         return self._learning_rate
@@ -116,12 +116,12 @@ class AdaBoostClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : AdaBoostClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -157,12 +157,12 @@ class AdaBoostClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -195,7 +195,7 @@ class AdaBoostClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.ensemble import AdaBoostClassifier as sk_AdaBoostClassifier

--- a/src/safeds/ml/classical/classification/_classifier.py
+++ b/src/safeds/ml/classical/classification/_classifier.py
@@ -36,12 +36,12 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : Classifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -57,12 +57,12 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -89,7 +89,7 @@ class Classifier(ABC):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
 
@@ -100,12 +100,12 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
 
         Returns
         -------
-        accuracy : float
+        accuracy:
             The calculated accuracy score, i.e. the percentage of equal data.
 
         Raises
@@ -129,14 +129,14 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
-        positive_class : Any
+        positive_class:
             The class to be considered positive. All other classes are considered negative.
 
         Returns
         -------
-        precision : float
+        precision:
             The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives.
             Return 1 if no positive predictions are made.
         """
@@ -166,14 +166,14 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
-        positive_class : Any
+        positive_class:
             The class to be considered positive. All other classes are considered negative.
 
         Returns
         -------
-        recall : float
+        recall:
             The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives.
             Return 1 if there are no positive expectations.
         """
@@ -203,14 +203,14 @@ class Classifier(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
-        positive_class : Any
+        positive_class:
             The class to be considered positive. All other classes are considered negative.
 
         Returns
         -------
-        f1_score : float
+        f1_score:
             The calculated $F_1$-score, i.e. the harmonic mean between precision and recall.
             Return 1 if there are no positive expectations and predictions.
         """

--- a/src/safeds/ml/classical/classification/_decision_tree.py
+++ b/src/safeds/ml/classical/classification/_decision_tree.py
@@ -34,12 +34,12 @@ class DecisionTreeClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : DecisionTreeClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -71,12 +71,12 @@ class DecisionTreeClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises

--- a/src/safeds/ml/classical/classification/_gradient_boosting.py
+++ b/src/safeds/ml/classical/classification/_gradient_boosting.py
@@ -21,10 +21,10 @@ class GradientBoostingClassifier(Classifier):
 
     Parameters
     ----------
-    number_of_trees: int
+    number_of_trees:
         The number of boosting stages to perform. Gradient boosting is fairly robust to over-fitting so a large
         number usually results in better performance.
-    learning_rate : float
+    learning_rate:
         The larger the value, the more the model is influenced by each additional tree. If the learning rate is too
         low, the model might underfit. If the learning rate is too high, the model might overfit.
 
@@ -66,7 +66,7 @@ class GradientBoostingClassifier(Classifier):
 
         Returns
         -------
-        result: int
+        result:
             The number of trees.
         """
         return self._number_of_trees
@@ -78,7 +78,7 @@ class GradientBoostingClassifier(Classifier):
 
         Returns
         -------
-        result: float
+        result:
             The learning rate.
         """
         return self._learning_rate
@@ -91,12 +91,12 @@ class GradientBoostingClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : GradientBoostingClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -128,12 +128,12 @@ class GradientBoostingClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -166,7 +166,7 @@ class GradientBoostingClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.ensemble import GradientBoostingClassifier as sk_GradientBoostingClassifier

--- a/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
@@ -21,7 +21,7 @@ class KNearestNeighborsClassifier(Classifier):
 
     Parameters
     ----------
-    number_of_neighbors : int
+    number_of_neighbors:
         The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and
         less than or equal to the sample size (validated when calling `fit`).
 
@@ -59,7 +59,7 @@ class KNearestNeighborsClassifier(Classifier):
 
         Returns
         -------
-        result: int
+        result:
             The number of neighbors.
         """
         return self._number_of_neighbors
@@ -72,12 +72,12 @@ class KNearestNeighborsClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : KNearestNeighborsClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -120,12 +120,12 @@ class KNearestNeighborsClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -158,7 +158,7 @@ class KNearestNeighborsClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.neighbors import KNeighborsClassifier as sk_KNeighborsClassifier

--- a/src/safeds/ml/classical/classification/_logistic_regression.py
+++ b/src/safeds/ml/classical/classification/_logistic_regression.py
@@ -34,12 +34,12 @@ class LogisticRegressionClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : LogisticRegressionClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -71,12 +71,12 @@ class LogisticRegressionClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -109,7 +109,7 @@ class LogisticRegressionClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.linear_model import LogisticRegression as sk_LogisticRegression

--- a/src/safeds/ml/classical/classification/_random_forest.py
+++ b/src/safeds/ml/classical/classification/_random_forest.py
@@ -20,7 +20,7 @@ class RandomForestClassifier(Classifier):
 
     Parameters
     ----------
-    number_of_trees : int
+    number_of_trees:
         The number of trees to be used in the random forest. Has to be greater than 0.
 
     Raises
@@ -57,7 +57,7 @@ class RandomForestClassifier(Classifier):
 
         Returns
         -------
-        result: int
+        result:
             The number of trees.
         """
         return self._number_of_trees
@@ -70,12 +70,12 @@ class RandomForestClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : RandomForestClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -107,12 +107,12 @@ class RandomForestClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -145,7 +145,7 @@ class RandomForestClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.ensemble import RandomForestClassifier as sk_RandomForestClassifier

--- a/src/safeds/ml/classical/classification/_support_vector_machine.py
+++ b/src/safeds/ml/classical/classification/_support_vector_machine.py
@@ -26,8 +26,8 @@ class SupportVectorMachineKernel(ABC):
 
         Returns
         -------
-        object
-        The kernel of the SupportVectorMachine.
+        kernel:
+            The kernel of the SupportVectorMachine.
         """
 
     @abstractmethod
@@ -64,9 +64,9 @@ class SupportVectorMachineClassifier(Classifier):
 
     Parameters
     ----------
-    c: float
+    c:
         The strength of regularization. Must be strictly positive.
-    kernel: SupportVectorMachineKernel | None
+    kernel:
         The type of kernel to be used. Defaults to None.
 
     Raises
@@ -97,7 +97,7 @@ class SupportVectorMachineClassifier(Classifier):
 
         Returns
         -------
-        result: float
+        result:
             The regularization strength.
         """
         return self._c
@@ -109,7 +109,7 @@ class SupportVectorMachineClassifier(Classifier):
 
         Returns
         -------
-        result: SupportVectorMachineKernel | None
+        result:
             The type of kernel used.
         """
         return self._kernel
@@ -122,7 +122,7 @@ class SupportVectorMachineClassifier(Classifier):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the linear kernel.
                 """
                 return "linear"
@@ -146,7 +146,7 @@ class SupportVectorMachineClassifier(Classifier):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the polynomial kernel.
                 """
                 return "poly"
@@ -177,7 +177,7 @@ class SupportVectorMachineClassifier(Classifier):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the sigmoid kernel.
                 """
                 return "sigmoid"
@@ -196,7 +196,7 @@ class SupportVectorMachineClassifier(Classifier):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the RBF kernel.
                 """
                 return "rbf"
@@ -214,7 +214,7 @@ class SupportVectorMachineClassifier(Classifier):
 
         Returns
         -------
-        result: str
+        result:
             The name of the kernel.
 
         Raises
@@ -241,12 +241,12 @@ class SupportVectorMachineClassifier(Classifier):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_classifier : SupportVectorMachineClassifier
+        fitted_classifier:
             The fitted classifier.
 
         Raises
@@ -278,12 +278,12 @@ class SupportVectorMachineClassifier(Classifier):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -316,7 +316,7 @@ class SupportVectorMachineClassifier(Classifier):
 
         Returns
         -------
-        wrapped_classifier: ClassifierMixin
+        wrapped_classifier:
             The sklearn Classifier.
         """
         from sklearn.svm import SVC as sk_SVC  # noqa: N811

--- a/src/safeds/ml/classical/regression/_ada_boost.py
+++ b/src/safeds/ml/classical/regression/_ada_boost.py
@@ -21,12 +21,12 @@ class AdaBoostRegressor(Regressor):
 
     Parameters
     ----------
-    learner: Regressor | None
+    learner:
         The learner from which the boosted ensemble is built.
-    maximum_number_of_learners: int
+    maximum_number_of_learners:
         The maximum number of learners at which boosting is terminated. In case of perfect fit, the learning procedure
         is stopped early. Has to be greater than 0.
-    learning_rate : float
+    learning_rate:
         Weight applied to each regressor at each boosting iteration. A higher learning rate increases the contribution
         of each regressor. Has to be greater than 0.
 
@@ -79,7 +79,7 @@ class AdaBoostRegressor(Regressor):
 
         Returns
         -------
-        result: Regressor | None
+        result:
             The base learner.
         """
         return self._learner
@@ -91,7 +91,7 @@ class AdaBoostRegressor(Regressor):
 
         Returns
         -------
-        result: int
+        result:
             The maximum number of learners.
         """
         return self._maximum_number_of_learners
@@ -103,7 +103,7 @@ class AdaBoostRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The learning rate.
         """
         return self._learning_rate
@@ -116,12 +116,12 @@ class AdaBoostRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : AdaBoostRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -157,12 +157,12 @@ class AdaBoostRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -195,7 +195,7 @@ class AdaBoostRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.ensemble import AdaBoostRegressor as sk_AdaBoostRegressor

--- a/src/safeds/ml/classical/regression/_decision_tree.py
+++ b/src/safeds/ml/classical/regression/_decision_tree.py
@@ -34,12 +34,12 @@ class DecisionTreeRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : DecisionTreeRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -71,12 +71,12 @@ class DecisionTreeRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -109,7 +109,7 @@ class DecisionTreeRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.tree import DecisionTreeRegressor as sk_DecisionTreeRegressor

--- a/src/safeds/ml/classical/regression/_elastic_net_regression.py
+++ b/src/safeds/ml/classical/regression/_elastic_net_regression.py
@@ -22,9 +22,9 @@ class ElasticNetRegressor(Regressor):
 
     Parameters
     ----------
-    alpha : float
+    alpha:
         Controls the regularization of the model. The higher the value, the more regularized it becomes.
-    lasso_ratio: float
+    lasso_ratio:
         Number between 0 and 1 that controls the ratio between Lasso and Ridge regularization. If 0, only Ridge
         regularization is used. If 1, only Lasso regularization is used.
 
@@ -96,7 +96,7 @@ class ElasticNetRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The regularization of the model.
         """
         return self._alpha
@@ -108,7 +108,7 @@ class ElasticNetRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The ratio between Lasso and Ridge regularization.
         """
         return self._lasso_ratio
@@ -121,12 +121,12 @@ class ElasticNetRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : ElasticNetRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -158,12 +158,12 @@ class ElasticNetRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -196,7 +196,7 @@ class ElasticNetRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.linear_model import ElasticNet as sk_ElasticNet

--- a/src/safeds/ml/classical/regression/_gradient_boosting.py
+++ b/src/safeds/ml/classical/regression/_gradient_boosting.py
@@ -21,10 +21,10 @@ class GradientBoostingRegressor(Regressor):
 
     Parameters
     ----------
-    number_of_trees: int
+    number_of_trees:
         The number of boosting stages to perform. Gradient boosting is fairly robust to over-fitting so a large
         number usually results in better performance.
-    learning_rate : float
+    learning_rate:
         The larger the value, the more the model is influenced by each additional tree. If the learning rate is too
         low, the model might underfit. If the learning rate is too high, the model might overfit.
 
@@ -66,7 +66,7 @@ class GradientBoostingRegressor(Regressor):
 
         Returns
         -------
-        result: int
+        result:
             The number of trees.
         """
         return self._number_of_trees
@@ -78,7 +78,7 @@ class GradientBoostingRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The learning rate.
         """
         return self._learning_rate
@@ -91,12 +91,12 @@ class GradientBoostingRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : GradientBoostingRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -128,12 +128,12 @@ class GradientBoostingRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -166,7 +166,7 @@ class GradientBoostingRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.ensemble import GradientBoostingRegressor as sk_GradientBoostingRegressor

--- a/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
@@ -21,7 +21,7 @@ class KNearestNeighborsRegressor(Regressor):
 
     Parameters
     ----------
-    number_of_neighbors : int
+    number_of_neighbors:
         The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and
         less than or equal to the sample size (validated when calling `fit`).
 
@@ -59,7 +59,7 @@ class KNearestNeighborsRegressor(Regressor):
 
         Returns
         -------
-        result: int
+        result:
             The number of neighbors.
         """
         return self._number_of_neighbors
@@ -72,12 +72,12 @@ class KNearestNeighborsRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : KNearestNeighborsRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -121,12 +121,12 @@ class KNearestNeighborsRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -159,7 +159,7 @@ class KNearestNeighborsRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.neighbors import KNeighborsRegressor as sk_KNeighborsRegressor

--- a/src/safeds/ml/classical/regression/_lasso_regression.py
+++ b/src/safeds/ml/classical/regression/_lasso_regression.py
@@ -21,7 +21,7 @@ class LassoRegressor(Regressor):
 
     Parameters
     ----------
-    alpha : float
+    alpha:
         Controls the regularization of the model. The higher the value, the more regularized it becomes.
 
     Raises
@@ -62,7 +62,7 @@ class LassoRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The regularization of the model.
         """
         return self._alpha
@@ -75,12 +75,12 @@ class LassoRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : LassoRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -112,12 +112,12 @@ class LassoRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -150,7 +150,7 @@ class LassoRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.linear_model import Lasso as sk_Lasso

--- a/src/safeds/ml/classical/regression/_linear_regression.py
+++ b/src/safeds/ml/classical/regression/_linear_regression.py
@@ -34,12 +34,12 @@ class LinearRegressionRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : LinearRegressionRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -71,12 +71,12 @@ class LinearRegressionRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -109,7 +109,7 @@ class LinearRegressionRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.linear_model import LinearRegression as sk_LinearRegression

--- a/src/safeds/ml/classical/regression/_random_forest.py
+++ b/src/safeds/ml/classical/regression/_random_forest.py
@@ -20,7 +20,7 @@ class RandomForestRegressor(Regressor):
 
     Parameters
     ----------
-    number_of_trees : int
+    number_of_trees:
         The number of trees to be used in the random forest. Has to be greater than 0.
 
     Raises
@@ -52,7 +52,7 @@ class RandomForestRegressor(Regressor):
 
         Returns
         -------
-        result: int
+        result:
             The number of trees.
         """
         return self._number_of_trees
@@ -65,12 +65,12 @@ class RandomForestRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : RandomForestRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -102,12 +102,12 @@ class RandomForestRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -140,7 +140,7 @@ class RandomForestRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.ensemble import RandomForestRegressor as sk_RandomForestRegressor

--- a/src/safeds/ml/classical/regression/_regressor.py
+++ b/src/safeds/ml/classical/regression/_regressor.py
@@ -34,12 +34,12 @@ class Regressor(ABC):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : Regressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -55,12 +55,12 @@ class Regressor(ABC):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -87,7 +87,7 @@ class Regressor(ABC):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
 
@@ -98,12 +98,12 @@ class Regressor(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
 
         Returns
         -------
-        mean_squared_error : float
+        mean_squared_error:
             The calculated mean squared error (the average of the distance of each individual row squared).
 
         Raises
@@ -128,12 +128,12 @@ class Regressor(ABC):
 
         Parameters
         ----------
-        validation_or_test_set : TaggedTable
+        validation_or_test_set:
             The validation or test set.
 
         Returns
         -------
-        mean_absolute_error : float
+        mean_absolute_error:
             The calculated mean absolute error (the average of the distance of each individual row).
 
         Raises

--- a/src/safeds/ml/classical/regression/_ridge_regression.py
+++ b/src/safeds/ml/classical/regression/_ridge_regression.py
@@ -22,7 +22,7 @@ class RidgeRegressor(Regressor):
 
     Parameters
     ----------
-    alpha : float
+    alpha:
         Controls the regularization of the model. The higher the value, the more regularized it becomes.
 
     Raises
@@ -63,7 +63,7 @@ class RidgeRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The regularization of the model.
         """
         return self._alpha
@@ -76,12 +76,12 @@ class RidgeRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : RidgeRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -113,12 +113,12 @@ class RidgeRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -151,7 +151,7 @@ class RidgeRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.linear_model import Ridge as sk_Ridge

--- a/src/safeds/ml/classical/regression/_support_vector_machine.py
+++ b/src/safeds/ml/classical/regression/_support_vector_machine.py
@@ -26,8 +26,8 @@ class SupportVectorMachineKernel(ABC):
 
         Returns
         -------
-        object
-        The kernel of the SupportVectorMachine.
+        kernel:
+            The kernel of the SupportVectorMachine.
         """
 
     @abstractmethod
@@ -64,9 +64,9 @@ class SupportVectorMachineRegressor(Regressor):
 
     Parameters
     ----------
-    c: float
+    c:
         The strength of regularization. Must be strictly positive.
-    kernel: SupportVectorMachineKernel | None
+    kernel:
         The type of kernel to be used. Defaults to None.
 
     Raises
@@ -97,7 +97,7 @@ class SupportVectorMachineRegressor(Regressor):
 
         Returns
         -------
-        result: float
+        result:
             The regularization strength.
         """
         return self._c
@@ -109,7 +109,7 @@ class SupportVectorMachineRegressor(Regressor):
 
         Returns
         -------
-        result: SupportVectorMachineKernel | None
+        result:
             The type of kernel used.
         """
         return self._kernel
@@ -122,7 +122,7 @@ class SupportVectorMachineRegressor(Regressor):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the linear kernel.
                 """
                 return "linear"
@@ -146,7 +146,7 @@ class SupportVectorMachineRegressor(Regressor):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the polynomial kernel.
                 """
                 return "poly"
@@ -177,7 +177,7 @@ class SupportVectorMachineRegressor(Regressor):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the sigmoid kernel.
                 """
                 return "sigmoid"
@@ -196,7 +196,7 @@ class SupportVectorMachineRegressor(Regressor):
 
                 Returns
                 -------
-                result: str
+                result:
                     The name of the RBF kernel.
                 """
                 return "rbf"
@@ -214,7 +214,7 @@ class SupportVectorMachineRegressor(Regressor):
 
         Returns
         -------
-        result: str
+        result:
             The name of the kernel.
 
         Raises
@@ -241,12 +241,12 @@ class SupportVectorMachineRegressor(Regressor):
 
         Parameters
         ----------
-        training_set : TaggedTable
+        training_set:
             The training data containing the feature and target vectors.
 
         Returns
         -------
-        fitted_regressor : SupportVectorMachineRegressor
+        fitted_regressor:
             The fitted regressor.
 
         Raises
@@ -278,12 +278,12 @@ class SupportVectorMachineRegressor(Regressor):
 
         Parameters
         ----------
-        dataset : Table
+        dataset:
             The dataset containing the feature vectors.
 
         Returns
         -------
-        table : TaggedTable
+        table:
             A dataset containing the given feature vectors and the predicted target vector.
 
         Raises
@@ -316,7 +316,7 @@ class SupportVectorMachineRegressor(Regressor):
 
         Returns
         -------
-        wrapped_regressor: RegressorMixin
+        wrapped_regressor:
             The sklearn Regressor.
         """
         from sklearn.svm import SVR as sk_SVR  # noqa: N811

--- a/src/safeds/ml/hyperparameters/_choice.py
+++ b/src/safeds/ml/hyperparameters/_choice.py
@@ -19,7 +19,7 @@ class Choice(Collection[T]):
 
         Parameters
         ----------
-        *args: tuple[T, ...]
+        *args:
             The values to choose from.
         """
         self.elements = list(args)
@@ -30,12 +30,12 @@ class Choice(Collection[T]):
 
         Parameters
         ----------
-        value: Any
+        value:
             The value to check.
 
         Returns
         -------
-        is_in_choice : bool
+        is_in_choice:
             Whether the value is in this choice.
         """
         return value in self.elements
@@ -46,7 +46,7 @@ class Choice(Collection[T]):
 
         Returns
         -------
-        iterator : Iterator[T]
+        iterator:
             An iterator over the values of this choice.
         """
         return iter(self.elements)
@@ -57,7 +57,7 @@ class Choice(Collection[T]):
 
         Returns
         -------
-        number_of_values : int
+        number_of_values:
             The number of values in this choice.
         """
         return len(self.elements)

--- a/src/safeds/ml/nn/_forward_layer.py
+++ b/src/safeds/ml/nn/_forward_layer.py
@@ -40,9 +40,9 @@ class ForwardLayer(_Layer):
 
         Parameters
         ----------
-        input_size
+        input_size:
             The number of neurons in the previous layer
-        output_size
+        output_size:
             The number of neurons in this layer
 
         Raises
@@ -68,7 +68,7 @@ class ForwardLayer(_Layer):
 
         Returns
         -------
-        result :
+        result:
             The amount of values being passed into this layer.
         """
         return self._input_size
@@ -80,7 +80,7 @@ class ForwardLayer(_Layer):
 
         Returns
         -------
-        result :
+        result:
             The Number of Neurons in this layer.
         """
         return self._output_size
@@ -117,8 +117,6 @@ class ForwardLayer(_Layer):
         return self._input_size == other._input_size and self._output_size == other._output_size
 
     def __sizeof__(self) -> int:
-        import sys
-
         """
         Return the complete size of this object.
 
@@ -127,4 +125,6 @@ class ForwardLayer(_Layer):
         size:
             Size of this object in bytes.
         """
+        import sys
+
         return sys.getsizeof(self._input_size) + sys.getsizeof(self._output_size)

--- a/src/safeds/ml/nn/_input_conversion_table.py
+++ b/src/safeds/ml/nn/_input_conversion_table.py
@@ -18,9 +18,9 @@ class InputConversionTable(_InputConversion[TaggedTable, Table]):
 
         Parameters
         ----------
-        feature_names
+        feature_names:
             The names of the features for the input table, used as features for the training.
-        target_name
+        target_name:
             The name of the target for the input table, used as target for the training.
         """
         self._feature_names = feature_names

--- a/src/safeds/ml/nn/_model.py
+++ b/src/safeds/ml/nn/_model.py
@@ -58,29 +58,29 @@ class NeuralNetworkRegressor(Generic[IFT, IPT, OT]):
 
         Parameters
         ----------
-        train_data
+        train_data:
             The data the network should be trained on.
-        epoch_size
+        epoch_size:
             The number of times the training cycle should be done.
-        batch_size
+        batch_size:
             The size of data batches that should be loaded at one time.
-        learning_rate
+        learning_rate:
             The learning rate of the neural network.
-        callback_on_batch_completion
+        callback_on_batch_completion:
             Function used to view metrics while training. Gets called after a batch is completed with the index of the last batch and the overall loss average.
-        callback_on_epoch_completion
+        callback_on_epoch_completion:
             Function used to view metrics while training. Gets called after an epoch is completed with the index of the last epoch and the overall loss average.
+
+        Returns
+        -------
+        trained_model:
+            The trained Model
 
         Raises
         ------
         ValueError
             If epoch_size < 1
             If batch_size < 1
-
-        Returns
-        -------
-        trained_model :
-            The trained Model
         """
         import torch
         from torch import nn
@@ -140,12 +140,12 @@ class NeuralNetworkRegressor(Generic[IFT, IPT, OT]):
 
         Parameters
         ----------
-        test_data
+        test_data:
             The data the network should predict.
 
         Returns
         -------
-        prediction :
+        prediction:
             The given test_data with an added "prediction" column at the end
 
         Raises
@@ -206,29 +206,29 @@ class NeuralNetworkClassifier(Generic[IFT, IPT, OT]):
 
         Parameters
         ----------
-        train_data
+        train_data:
             The data the network should be trained on.
-        epoch_size
+        epoch_size:
             The number of times the training cycle should be done.
-        batch_size
+        batch_size:
             The size of data batches that should be loaded at one time.
-        learning_rate
+        learning_rate:
             The learning rate of the neural network.
-        callback_on_batch_completion
+        callback_on_batch_completion:
             Function used to view metrics while training. Gets called after a batch is completed with the index of the last batch and the overall loss average.
-        callback_on_epoch_completion
+        callback_on_epoch_completion:
             Function used to view metrics while training. Gets called after an epoch is completed with the index of the last epoch and the overall loss average.
+
+        Returns
+        -------
+        trained_model:
+            The trained Model
 
         Raises
         ------
         ValueError
             If epoch_size < 1
             If batch_size < 1
-
-        Returns
-        -------
-        trained_model :
-            The trained Model
         """
         import torch
         from torch import nn
@@ -295,12 +295,12 @@ class NeuralNetworkClassifier(Generic[IFT, IPT, OT]):
 
         Parameters
         ----------
-        test_data
+        test_data:
             The data the network should predict.
 
         Returns
         -------
-        prediction :
+        prediction:
             The given test_data with an added "prediction" column at the end
 
         Raises

--- a/src/safeds/ml/nn/_output_conversion_table.py
+++ b/src/safeds/ml/nn/_output_conversion_table.py
@@ -18,7 +18,7 @@ class OutputConversionTable(_OutputConversion[Table, TaggedTable]):
 
         Parameters
         ----------
-        prediction_name
+        prediction_name:
             The name of the new column where the prediction will be stored.
         """
         self._prediction_name = prediction_name


### PR DESCRIPTION
Closes #532

### Summary of Changes

Remove all type hints from parameters & results in docstrings. Types are now only listed in the code to prevent inconsistencies.