### PR TITLE
feat: callback `Row.sort_columns` takes four parameters instead of two tuples

### DIFF
--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -507,10 +507,13 @@ class Row(Mapping[str, Any]):
         new_row:
             A new row with sorted columns.
         """
+        def cmp(column_1: tuple[str, Any], column_2: tuple[str, Any]) -> int:
+            return comparator(column_1[0], column_1[1], column_2[0], column_2[1])
+
         sorted_row_dict = dict(
             sorted(
                 self.to_dict().items(),
-                key=functools.cmp_to_key(lambda col1, col2: comparator(col1[0], col1[1], col2[0], col2[1])),
+                key=functools.cmp_to_key(cmp),
             ),
         )
         return Row.from_dict(sorted_row_dict)

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -476,8 +476,10 @@ class Row(Mapping[str, Any]):
 
     def sort_columns(
         self,
-        comparator: Callable[[str, Any, str, Any], int] =
-            lambda name_1, _value_1, name_2, _value_2: (name_1[0] > name_2[0]) - (name_1[0] < name_2[0]),
+        comparator: Callable[[str, Any, str, Any], int] = lambda name_1, _value_1, name_2, _value_2: (
+            name_1[0] > name_2[0]
+        )
+        - (name_1[0] < name_2[0]),
     ) -> Row:
         """
         Sort the columns of a `Row` with the given comparator and return a new `Row`.
@@ -507,6 +509,7 @@ class Row(Mapping[str, Any]):
         new_row:
             A new row with sorted columns.
         """
+
         def cmp(column_1: tuple[str, Any], column_2: tuple[str, Any]) -> int:
             return comparator(column_1[0], column_1[1], column_2[0], column_2[1])
 

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -476,13 +476,20 @@ class Row(Mapping[str, Any]):
 
     def sort_columns(
         self,
-        comparator: Callable[[tuple, tuple], int] = lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]),
+        comparator: Callable[[str, Any, str, Any], int] =
+            lambda name_1, _value_1, name_2, _value_2: (name_1[0] > name_2[0]) - (name_1[0] < name_2[0]),
     ) -> Row:
         """
         Sort the columns of a `Row` with the given comparator and return a new `Row`.
 
-        The original row is not modified. The comparator is a function that takes two tuples of (ColumnName,
-        Value) `col1` and `col2` and returns an integer:
+        The original row is not modified. The comparator is a function with four parameters:
+
+        * `name_1` is the name of the first column.
+        * `value_1` is the value of the first column.
+        * `name_2` is the name of the second column.
+        * `value_2` is the value of the second column.
+
+        It should return an integer, indicating the desired order of the columns:
 
         * If `col1` should be ordered before `col2`, the function should return a negative number.
         * If `col1` should be ordered after `col2`, the function should return a positive number.
@@ -500,7 +507,12 @@ class Row(Mapping[str, Any]):
         new_row:
             A new row with sorted columns.
         """
-        sorted_row_dict = dict(sorted(self.to_dict().items(), key=functools.cmp_to_key(comparator)))
+        sorted_row_dict = dict(
+            sorted(
+                self.to_dict().items(),
+                key=functools.cmp_to_key(lambda col1, col2: comparator(col1[0], col1[1], col2[0], col2[1])),
+            ),
+        )
         return Row.from_dict(sorted_row_dict)
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -553,12 +553,12 @@ class TestSortColumns:
         [
             (
                 Row({"b": 1, "a": 2}),
-                lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]),
+                lambda name_1, _value_1, name_2, _value_2: (name_1 > name_2) - (name_1 < name_2),
                 Row({"a": 2, "b": 1}),
             ),
             (
                 Row({"a": 2, "b": 1}),
-                lambda col1, col2: (col2[0] > col1[0]) - (col2[0] < col1[0]),
+                lambda name_1, _value_1, name_2, _value_2: (name_2 > name_1) - (name_2 < name_1),
                 Row({"b": 1, "a": 2}),
             ),
             (Row(), lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]), Row()),
@@ -569,7 +569,7 @@ class TestSortColumns:
             "empty rows",
         ],
     )
-    def test_should_sort_columns(self, row: Row, comparator: Callable[[tuple, tuple], int], expected: Row) -> None:
+    def test_should_sort_columns(self, row: Row, comparator: Callable[[str, Any, str, Any], int], expected: Row) -> None:
         row = row.sort_columns(comparator)
         assert row == expected
 

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -569,7 +569,9 @@ class TestSortColumns:
             "empty rows",
         ],
     )
-    def test_should_sort_columns(self, row: Row, comparator: Callable[[str, Any, str, Any], int], expected: Row) -> None:
+    def test_should_sort_columns(
+        self, row: Row, comparator: Callable[[str, Any, str, Any], int], expected: Row,
+    ) -> None:
         row = row.sort_columns(comparator)
         assert row == expected
 

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -570,7 +570,10 @@ class TestSortColumns:
         ],
     )
     def test_should_sort_columns(
-        self, row: Row, comparator: Callable[[str, Any, str, Any], int], expected: Row,
+        self,
+        row: Row,
+        comparator: Callable[[str, Any, str, Any], int],
+        expected: Row,
     ) -> None:
         row = row.sort_columns(comparator)
         assert row == expected


### PR DESCRIPTION
Closes #584

### Summary of Changes

`Row.sort_columns` now takes four parameters `name1`, `value1`, `name2`, `value2` instead of two tuples of shape `(name1, value1)`, `(name2, value2)`.
