### PR TITLE
feat: allow using tables that already contain target for prediction

### DIFF
--- a/src/safeds/exceptions/__init__.py
+++ b/src/safeds/exceptions/__init__.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
         OutOfBoundsError,
     )
     from safeds.exceptions._ml import (
-        DatasetContainsTargetError,
         DatasetMissesDataError,
         DatasetMissesFeaturesError,
         FeatureDataMismatchError,
@@ -63,7 +62,6 @@ apipkg.initpkg(
         "ValueNotPresentWhenFittedError": "._data:ValueNotPresentWhenFittedError",
         "WrongFileExtensionError": "._data:WrongFileExtensionError",
         # ML exceptions
-        "DatasetContainsTargetError": "._ml:DatasetContainsTargetError",
         "DatasetMissesDataError": "._ml:DatasetMissesDataError",
         "DatasetMissesFeaturesError": "._ml:DatasetMissesFeaturesError",
         "FeatureDataMismatchError": "._ml:FeatureDataMismatchError",
@@ -100,7 +98,6 @@ __all__ = [
     "ValueNotPresentWhenFittedError",
     "WrongFileExtensionError",
     # ML exceptions
-    "DatasetContainsTargetError",
     "DatasetMissesDataError",
     "DatasetMissesFeaturesError",
     "FeatureDataMismatchError",

--- a/src/safeds/exceptions/_ml.py
+++ b/src/safeds/exceptions/_ml.py
@@ -1,17 +1,3 @@
-class DatasetContainsTargetError(ValueError):
-    """
-    Raised when a dataset contains the target column already.
-
-    Parameters
-    ----------
-    target_name:
-        The name of the target column.
-    """
-
-    def __init__(self, target_name: str):
-        super().__init__(f"Dataset already contains the target column '{target_name}'.")
-
-
 class DatasetMissesFeaturesError(ValueError):
     """
     Raised when a dataset misses feature columns.

--- a/src/safeds/ml/classical/_util_sklearn.py
+++ b/src/safeds/ml/classical/_util_sklearn.py
@@ -4,7 +4,6 @@ from typing import Any
 from safeds.data.labeled.containers import TabularDataset
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import (
-    DatasetContainsTargetError,
     DatasetMissesDataError,
     DatasetMissesFeaturesError,
     LearningError,
@@ -102,8 +101,6 @@ def predict(model: Any, dataset: Table, feature_names: list[str] | None, target_
     ------
     ModelNotFittedError
         If the model has not been fitted yet.
-    DatasetContainsTargetError
-        If the dataset contains the target column already.
     DatasetMissesFeaturesError
         If the dataset misses feature columns.
     PredictionError
@@ -118,8 +115,6 @@ def predict(model: Any, dataset: Table, feature_names: list[str] | None, target_
     # Validation
     if model is None or target_name is None or feature_names is None:
         raise ModelNotFittedError
-    if dataset.has_column(target_name):
-        raise DatasetContainsTargetError(target_name)
     missing_feature_names = [feature_name for feature_name in feature_names if not dataset.has_column(feature_name)]
     if missing_feature_names:
         raise DatasetMissesFeaturesError(missing_feature_names)

--- a/src/safeds/ml/classical/classification/_ada_boost.py
+++ b/src/safeds/ml/classical/classification/_ada_boost.py
@@ -170,8 +170,6 @@ class AdaBoostClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_classifier.py
+++ b/src/safeds/ml/classical/classification/_classifier.py
@@ -70,8 +70,6 @@ class Classifier(ABC):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_decision_tree.py
+++ b/src/safeds/ml/classical/classification/_decision_tree.py
@@ -84,8 +84,6 @@ class DecisionTreeClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_gradient_boosting.py
+++ b/src/safeds/ml/classical/classification/_gradient_boosting.py
@@ -141,8 +141,6 @@ class GradientBoostingClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/classification/_k_nearest_neighbors.py
@@ -134,8 +134,6 @@ class KNearestNeighborsClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_logistic_regression.py
+++ b/src/safeds/ml/classical/classification/_logistic_regression.py
@@ -84,8 +84,6 @@ class LogisticRegressionClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_random_forest.py
+++ b/src/safeds/ml/classical/classification/_random_forest.py
@@ -120,8 +120,6 @@ class RandomForestClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/classification/_support_vector_machine.py
+++ b/src/safeds/ml/classical/classification/_support_vector_machine.py
@@ -245,8 +245,6 @@ class SupportVectorMachineClassifier(Classifier):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_ada_boost.py
+++ b/src/safeds/ml/classical/regression/_ada_boost.py
@@ -170,8 +170,6 @@ class AdaBoostRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_decision_tree.py
+++ b/src/safeds/ml/classical/regression/_decision_tree.py
@@ -84,8 +84,6 @@ class DecisionTreeRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_elastic_net_regression.py
+++ b/src/safeds/ml/classical/regression/_elastic_net_regression.py
@@ -171,8 +171,6 @@ class ElasticNetRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_gradient_boosting.py
+++ b/src/safeds/ml/classical/regression/_gradient_boosting.py
@@ -141,8 +141,6 @@ class GradientBoostingRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classical/regression/_k_nearest_neighbors.py
@@ -136,8 +136,6 @@ class KNearestNeighborsRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_lasso_regression.py
+++ b/src/safeds/ml/classical/regression/_lasso_regression.py
@@ -125,8 +125,6 @@ class LassoRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_linear_regression.py
+++ b/src/safeds/ml/classical/regression/_linear_regression.py
@@ -84,8 +84,6 @@ class LinearRegressionRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_random_forest.py
+++ b/src/safeds/ml/classical/regression/_random_forest.py
@@ -115,8 +115,6 @@ class RandomForestRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_regressor.py
+++ b/src/safeds/ml/classical/regression/_regressor.py
@@ -68,8 +68,6 @@ class Regressor(ABC):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_ridge_regression.py
+++ b/src/safeds/ml/classical/regression/_ridge_regression.py
@@ -126,8 +126,6 @@ class RidgeRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/src/safeds/ml/classical/regression/_support_vector_machine.py
+++ b/src/safeds/ml/classical/regression/_support_vector_machine.py
@@ -245,8 +245,6 @@ class SupportVectorMachineRegressor(Regressor):
         ------
         ModelNotFittedError
             If the model has not been fitted yet.
-        DatasetContainsTargetError
-            If the dataset contains the target column already.
         DatasetMissesFeaturesError
             If the dataset misses feature columns.
         PredictionError

--- a/tests/safeds/ml/classical/classification/test_classifier.py
+++ b/tests/safeds/ml/classical/classification/test_classifier.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import (
-    DatasetContainsTargetError,
     DatasetMissesDataError,
     DatasetMissesFeaturesError,
     MissingValuesColumnError,
@@ -189,11 +188,6 @@ class TestPredict:
     def test_should_raise_if_not_fitted(self, classifier: Classifier, valid_data: TabularDataset) -> None:
         with pytest.raises(ModelNotFittedError):
             classifier.predict(valid_data.features)
-
-    def test_should_raise_if_dataset_contains_target(self, classifier: Classifier, valid_data: TabularDataset) -> None:
-        fitted_classifier = classifier.fit(valid_data)
-        with pytest.raises(DatasetContainsTargetError, match="target"):
-            fitted_classifier.predict(valid_data.to_table())
 
     def test_should_raise_if_dataset_misses_features(self, classifier: Classifier, valid_data: TabularDataset) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classical/regression/test_regressor.py
+++ b/tests/safeds/ml/classical/regression/test_regressor.py
@@ -8,7 +8,6 @@ import pytest
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import (
     ColumnLengthMismatchError,
-    DatasetContainsTargetError,
     DatasetMissesDataError,
     DatasetMissesFeaturesError,
     MissingValuesColumnError,
@@ -190,11 +189,6 @@ class TestPredict:
     def test_should_raise_if_not_fitted(self, regressor: Regressor, valid_data: TabularDataset) -> None:
         with pytest.raises(ModelNotFittedError):
             regressor.predict(valid_data.features)
-
-    def test_should_raise_if_dataset_contains_target(self, regressor: Regressor, valid_data: TabularDataset) -> None:
-        fitted_regressor = regressor.fit(valid_data)
-        with pytest.raises(DatasetContainsTargetError, match="target"):
-            fitted_regressor.predict(valid_data.to_table())
 
     def test_should_raise_if_dataset_misses_features(self, regressor: Regressor, valid_data: TabularDataset) -> None:
         fitted_regressor = regressor.fit(valid_data)


### PR DESCRIPTION
Closes #636

### Summary of Changes

No longer raise an error if a table that already contains the target is passed to `predict`. It's now simply ignored for training and overwritten.
