### PR TITLE
docs: hide dunder methods

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ plugins:
             - src
           options:
             docstring_style: numpy
+            filters:
+              - "!^_"  # Hide internal & dunder methods
             show_if_no_docstring: true
   - gen-files:
       scripts:


### PR DESCRIPTION
### Summary of Changes

Hide dunder methods in API documentation to reduce clutter.
