### PR TITLE
feat: add `Column.to_table`

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -18,6 +18,7 @@ from safeds.exceptions import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from safeds.data.tabular.containers import Table
 
     import pandas as pd
 
@@ -1015,8 +1016,22 @@ class Column(Sequence[T]):
     # Conversion
     # ------------------------------------------------------------------------------------------------------------------
 
+    def to_table(self) -> Table:
+        """
+        Create a table that contains only this column.
+
+        Returns
+        -------
+        table:
+            The table with this column.
+        """
+        # Must be imported here to avoid circular imports
+        from safeds.data.tabular.containers import Table
+
+        return Table.from_columns([self])
+
     def to_html(self) -> str:
-        r"""
+        """
         Return an HTML representation of the column.
 
         Returns
@@ -1040,7 +1055,7 @@ class Column(Sequence[T]):
     # ------------------------------------------------------------------------------------------------------------------
 
     def _repr_html_(self) -> str:
-        r"""
+        """
         Return an HTML representation of the column.
 
         Returns

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -18,9 +18,10 @@ from safeds.exceptions import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from safeds.data.tabular.containers import Table
 
     import pandas as pd
+
+    from safeds.data.tabular.containers import Table
 
 
 T = TypeVar("T")

--- a/tests/safeds/data/tabular/containers/_column/test_to_table.py
+++ b/tests/safeds/data/tabular/containers/_column/test_to_table.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_to_table.py
+++ b/tests/safeds/data/tabular/containers/_column/test_to_table.py
@@ -1,0 +1,18 @@
+import pytest
+
+from safeds.data.tabular.containers import Column, Table
+
+
+@pytest.mark.parametrize(
+    argnames=("column", "expected"),
+    argvalues=[
+        (Column("A", []), Table({"A": []})),
+        (Column("A", [1, 2, 3]), Table({"A": [1, 2, 3]})),
+    ],
+    ids=[
+        "empty",
+        "non-empty",
+    ],
+)
+def test_should_return_a_table_with_this_column(column: Column, expected: Table) -> None:
+    assert column.to_table() == expected


### PR DESCRIPTION
Closes #695

### Summary of Changes

Add method `Column.to_table` to get a `Table` from a `Column`.
