### PR TITLE
ci: disable MacOS again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - "ubuntu-latest"
+          # - "macos-latest" # Intel Macs are no longer supported by Torch
+          - "windows-latest"
         python-version:
           - "3.11"
           - "3.12"
@@ -22,6 +22,6 @@ jobs:
       platform: ${{ matrix.platform }}
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-      coverage: ${{ matrix.python-version == '3.11' }}
+      coverage: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - "ubuntu-latest"
+          # - "macos-latest" # Intel Macs are no longer supported by Torch
+          - "windows-latest"
         python-version:
           - "3.11"
           - "3.12"
@@ -26,6 +26,6 @@ jobs:
       platform: ${{ matrix.platform }}
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-      coverage: ${{ matrix.python-version == '3.11' }}
+      coverage: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

Disable the MacOS tests again, since PyTorch cannot be installed on them. Long term, we should activate these tests and only upgrade once they pass.
