### PR TITLE
feat: added Column.summarize_statistics()

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -405,7 +405,7 @@ class Column(Sequence[T]):
     # ------------------------------------------------------------------------------------------------------------------
     # Information
     # ------------------------------------------------------------------------------------------------------------------
-    
+
     def summarize_statistics(self) -> Table:
         """
         Return a table with a number of statistical key values.
@@ -420,7 +420,7 @@ class Column(Sequence[T]):
         Examples
         --------
         >>> from safeds.data.tabular.containers import Column
-        >>> column = Column("a", [1, 2, 3])
+        >>> column = Column("a", [1, 3])
         >>> column.summarize_statistics()
                          metric                   a
         0               minimum                   1
@@ -438,7 +438,7 @@ class Column(Sequence[T]):
         from safeds.data.tabular.containers import Table
 
         return Table({self._name: self._data}).summarize_statistics()
-    
+
     def all(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if all values have a given property.
@@ -1011,9 +1011,14 @@ class Column(Sequence[T]):
         buffer.seek(0)
         return Image.from_bytes(buffer.read())
 
-    def plot_histogram(self) -> Image:
+    def plot_histogram(self, *, number_of_bins: int = 10) -> Image:
         """
         Plot a column in a histogram.
+
+        Parameters
+        ----------
+        number_of_bins:
+            The number of bins to use in the histogram. Default is 10.
 
         Returns
         -------
@@ -1026,25 +1031,8 @@ class Column(Sequence[T]):
         >>> column = Column("test", [1, 2, 3])
         >>> histogram = column.plot_histogram()
         """
-        import matplotlib.pyplot as plt
-        import seaborn as sns
-
-        fig = plt.figure()
-        ax = sns.histplot(data=self._data)
-        ax.set_xticks(ax.get_xticks())
-        ax.set(xlabel=self.name)
-        ax.set_xticklabels(
-            ax.get_xticklabels(),
-            rotation=45,
-            horizontalalignment="right",
-        )  # rotate the labels of the x Axis to prevent the chance of overlapping of the labels
-        plt.tight_layout()
-
-        buffer = io.BytesIO()
-        fig.savefig(buffer, format="png")
-        plt.close()  # Prevents the figure from being displayed directly
-        buffer.seek(0)
-        return Image.from_bytes(buffer.read())
+        from safeds.data.tabular.containers import Table
+        return Table({self.name: self._data.array.tolist()}).plot_histograms(number_of_bins=number_of_bins)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Conversion

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -406,39 +406,6 @@ class Column(Sequence[T]):
     # Information
     # ------------------------------------------------------------------------------------------------------------------
 
-    def summarize_statistics(self) -> Table:
-        """
-        Return a table with a number of statistical key values.
-
-        The original Column is not modified.
-
-        Returns
-        -------
-        result:
-            The table with statistics.
-
-        Examples
-        --------
-        >>> from safeds.data.tabular.containers import Column
-        >>> column = Column("a", [1, 3])
-        >>> column.summarize_statistics()
-                         metric                   a
-        0               minimum                   1
-        1               maximum                   3
-        2                  mean                 2.0
-        3                  mode              [1, 3]
-        4                median                 2.0
-        5              variance                 2.0
-        6    standard deviation  1.4142135623730951
-        7   missing value count                   0
-        8   missing value ratio                 0.0
-        9                idness                 1.0
-        10            stability                 0.5
-        """
-        from safeds.data.tabular.containers import Table
-
-        return Table({self._name: self._data}).summarize_statistics()
-
     def all(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if all values have a given property.
@@ -598,6 +565,39 @@ class Column(Sequence[T]):
     # ------------------------------------------------------------------------------------------------------------------
     # Statistics
     # ------------------------------------------------------------------------------------------------------------------
+
+    def summarize_statistics(self) -> Table:
+        """
+        Return a table with a number of statistical key values.
+
+        The original Column is not modified.
+
+        Returns
+        -------
+        statistics:
+            The table with statistics.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Column
+        >>> column = Column("a", [1, 3])
+        >>> column.summarize_statistics()
+                         metric                   a
+        0               minimum                   1
+        1               maximum                   3
+        2                  mean                 2.0
+        3                  mode              [1, 3]
+        4                median                 2.0
+        5              variance                 2.0
+        6    standard deviation  1.4142135623730951
+        7   missing value count                   0
+        8   missing value ratio                 0.0
+        9                idness                 1.0
+        10            stability                 0.5
+        """
+        from safeds.data.tabular.containers import Table
+
+        return Table({self._name: self._data}).summarize_statistics()
 
     def correlation_with(self, other_column: Column) -> float:
         """

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -405,7 +405,40 @@ class Column(Sequence[T]):
     # ------------------------------------------------------------------------------------------------------------------
     # Information
     # ------------------------------------------------------------------------------------------------------------------
+    
+    def summarize_statistics(self) -> Table:
+        """
+        Return a table with a number of statistical key values.
 
+        The original Column is not modified.
+
+        Returns
+        -------
+        result:
+            The table with statistics.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Column
+        >>> column = Column("a", [1, 2, 3])
+        >>> column.summarize_statistics()
+                         metric                   a
+        0               minimum                   1
+        1               maximum                   3
+        2                  mean                 2.0
+        3                  mode              [1, 3]
+        4                median                 2.0
+        5              variance                 2.0
+        6    standard deviation  1.4142135623730951
+        7   missing value count                   0
+        8   missing value ratio                 0.0
+        9                idness                 1.0
+        10            stability                 0.5
+        """
+        from safeds.data.tabular.containers import Table
+
+        return Table({self._name: self._data}).summarize_statistics()
+    
     def all(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if all values have a given property.

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1011,14 +1011,9 @@ class Column(Sequence[T]):
         buffer.seek(0)
         return Image.from_bytes(buffer.read())
 
-    def plot_histogram(self, *, number_of_bins: int = 10) -> Image:
+    def plot_histogram(self) -> Image:
         """
         Plot a column in a histogram.
-
-        Parameters
-        ----------
-        number_of_bins:
-            The number of bins to use in the histogram. Default is 10.
 
         Returns
         -------
@@ -1031,8 +1026,25 @@ class Column(Sequence[T]):
         >>> column = Column("test", [1, 2, 3])
         >>> histogram = column.plot_histogram()
         """
-        from safeds.data.tabular.containers import Table
-        return Table({self.name: self._data.array.tolist()}).plot_histograms(number_of_bins=number_of_bins)
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+
+        fig = plt.figure()
+        ax = sns.histplot(data=self._data)
+        ax.set_xticks(ax.get_xticks())
+        ax.set(xlabel=self.name)
+        ax.set_xticklabels(
+            ax.get_xticklabels(),
+            rotation=45,
+            horizontalalignment="right",
+        )  # rotate the labels of the x Axis to prevent the chance of overlapping of the labels
+        plt.tight_layout()
+
+        buffer = io.BytesIO()
+        fig.savefig(buffer, format="png")
+        plt.close()  # Prevents the figure from being displayed directly
+        buffer.seek(0)
+        return Image.from_bytes(buffer.read())
 
     # ------------------------------------------------------------------------------------------------------------------
     # Conversion

--- a/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
@@ -74,26 +74,6 @@ from safeds.data.tabular.containers import Table, Column
             ),
         ),
         (
-            Column(),
-            Table(
-                {
-                    "metric": [
-                        "minimum",
-                        "maximum",
-                        "mean",
-                        "mode",
-                        "median",
-                        "variance",
-                        "standard deviation",
-                        "missing value count",
-                        "missing value ratio",
-                        "idness",
-                        "stability",
-                    ],
-                },
-            ),
-        ),
-        (
             Column("col", [None, None]),
             Table(
                 {
@@ -118,7 +98,6 @@ from safeds.data.tabular.containers import Table, Column
     ids=[
         "Column of integers", 
         "Column of characters",
-        "empty Column",
         "Column of None",
     ],
 )

--- a/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
@@ -1,0 +1,127 @@
+from statistics import stdev
+
+import pytest
+from safeds.data.tabular.containers import Table, Column
+
+
+@pytest.mark.parametrize(
+    ("column", "expected"),
+    [
+        (
+            Column("col1", [1, 2, 1]),
+            Table(
+                {
+                    "metric": [
+                        "minimum",
+                        "maximum",
+                        "mean",
+                        "mode",
+                        "median",
+                        "variance",
+                        "standard deviation",
+                        "missing value count",
+                        "missing value ratio",
+                        "idness",
+                        "stability",
+                    ],
+                    "col1": [
+                        "1",
+                        "2",
+                        str(4.0 / 3),
+                        "[1]",
+                        "1.0",
+                        str(1.0 / 3),
+                        str(stdev([1, 2, 1])),
+                        "0",
+                        "0.0",
+                        str(2.0 / 3),
+                        str(2.0 / 3),
+                    ],
+                },
+            ),
+        ),
+        (
+            Column("col1", ["a", "b", "c"]),
+            Table(
+                {
+                    "metric": [
+                        "minimum",
+                        "maximum",
+                        "mean",
+                        "mode",
+                        "median",
+                        "variance",
+                        "standard deviation",
+                        "missing value count",
+                        "missing value ratio",
+                        "idness",
+                        "stability",
+                    ],
+                    "col1": [
+                        "-",
+                        "-",
+                        "-",
+                        "['a', 'b', 'c']",
+                        "-",
+                        "-",
+                        "-",
+                        "0",
+                        "0.0",
+                        "1.0",
+                        str(1.0 / 3),
+                    ],
+                },
+            ),
+        ),
+        (
+            Column(),
+            Table(
+                {
+                    "metric": [
+                        "minimum",
+                        "maximum",
+                        "mean",
+                        "mode",
+                        "median",
+                        "variance",
+                        "standard deviation",
+                        "missing value count",
+                        "missing value ratio",
+                        "idness",
+                        "stability",
+                    ],
+                },
+            ),
+        ),
+        (
+            Column("col", [None, None]),
+            Table(
+                {
+                    "metric": [
+                        "minimum",
+                        "maximum",
+                        "mean",
+                        "mode",
+                        "median",
+                        "variance",
+                        "standard deviation",
+                        "missing value count",
+                        "missing value ratio",
+                        "idness",
+                        "stability",
+                    ],
+                    "col": ["-", "-", "-", "[]", "-", "-", "-", "2", "1.0", "0.0", "-"],
+                },
+            ),
+        ),
+    ],
+    ids=[
+        "Column of integers", 
+        "Column of characters",
+        "empty Column",
+        "Column of None",
+    ],
+)
+def test_should_summarize_statistics(column: Column, expected: Table) -> None:
+    assert column.summarize_statistics().schema == expected.schema
+    assert column.summarize_statistics() == expected

--- a/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
@@ -1,7 +1,7 @@
 from statistics import stdev
 
 import pytest
-from safeds.data.tabular.containers import Table, Column
+from safeds.data.tabular.containers import Column, Table
 
 
 @pytest.mark.parametrize(
@@ -96,7 +96,7 @@ from safeds.data.tabular.containers import Table, Column
         ),
     ],
     ids=[
-        "Column of integers", 
+        "Column of integers",
         "Column of characters",
         "Column of None",
     ],


### PR DESCRIPTION
Closes #701

### Summary of Changes

Added `summarize_statistics` to the `Column` class to quickly get an overview of relevant statistics.

The Column is converted into a Table with one Column and the results from Table.summarize_statistics() are returned. This way, if someone adds a new feature to Table.summarize_statistics(), it also appears in Column.summarize_statistics().
