### PR TITLE
feat: deprecate `Table.add_column` and `Table.add_row`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,6 +31,13 @@ Get the latest version from [PyPI](https://pypi.org/project/safe-ds):
 pip install safe-ds
 ```
 
+On a Windows PC with an NVIDIA graphics card, you may also want to install the CUDA versions of `torch` and
+`torchvision`:
+
+```shell
+pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu121
+```
+
 ## Documentation
 
 You can find the full documentation [here](https://library.safeds.com).

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,8 @@ Get the latest version from [PyPI](https://pypi.org/project/safe-ds):
 pip install safe-ds
 ```
 
-On a Windows PC with an NVIDIA graphics card, you may also want to install the CUDA versions of `torch` and `torchvision`:
+On a Windows PC with an NVIDIA graphics card, you may also want to install the CUDA versions of `torch` and
+`torchvision`:
 
 ```shell
 pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu121

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -898,6 +898,9 @@ class Table:
 
         The original table is not modified.
 
+        !!! warning "Deprecated"
+            Use [add_columns][safeds.data.tabular.containers._table.Table.add_columns] instead.
+
         Returns
         -------
         result:
@@ -920,16 +923,13 @@ class Table:
         0  1  2  d
         1  3  4  e
         """
-        if self.has_column(column.name):
-            raise DuplicateColumnNameError(column.name)
+        warnings.warn(
+            "This method is deprecated and will be removed in a future version. Use `Table.add_columns` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        if column.number_of_rows != self.number_of_rows and self.number_of_columns != 0:
-            raise ColumnSizeError(str(self.number_of_rows), str(column._data.size))
-
-        result = self._data.reset_index(drop=True)
-        result.columns = self._schema.column_names
-        result[column.name] = column._data
-        return Table._from_pandas_dataframe(result)
+        return self.add_columns([column])
 
     def add_columns(self, columns: list[Column] | Table) -> Table:
         """
@@ -990,6 +990,9 @@ class Table:
 
         The original table is not modified.
 
+        !!! warning "Deprecated"
+            Use [add_rows][safeds.data.tabular.containers._table.Table.add_rows] instead.
+
         Parameters
         ----------
         row:
@@ -1015,6 +1018,12 @@ class Table:
         0  1  2
         1  3  4
         """
+        warnings.warn(
+            "This method is deprecated and will be removed in a future version. Use `Table.add_rows` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         import numpy as np
         import pandas as pd
 
@@ -1161,6 +1170,7 @@ class Table:
             DeprecationWarning,
             stacklevel=2,
         )
+
         return self.keep_only_rows(query)
 
     _T = TypeVar("_T")


### PR DESCRIPTION
Closes #722

### Summary of Changes

* Deprecate `Table.add_column` in favor of `Table.add_columns`.
* Deprecate `Table.add_row` in favor of `Table.add_rows`.
