### PR TITLE
feat: return fitted transformer and transformed table from `fit_and_transform`

### DIFF
--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -116,7 +116,6 @@ class Imputer(TableTransformer):
         """Whether the transformer is fitted."""
         return self._wrapped_transformer is not None
 
-    # noinspection PyProtectedMember
     def fit(self, table: Table, column_names: list[str] | None) -> Imputer:
         """
         Learn a transformation for a set of columns in a table.
@@ -199,7 +198,6 @@ class Imputer(TableTransformer):
 
         return result
 
-    # noinspection PyProtectedMember
     def transform(self, table: Table) -> Table:
         """
         Apply the learned transformation to a table.

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from sklearn.preprocessing import OrdinalEncoder as sk_OrdinalEncoder
 
 
-# noinspection PyProtectedMember
 class LabelEncoder(InvertibleTableTransformer):
     """The LabelEncoder encodes one or more given columns into labels."""
 

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -65,7 +65,6 @@ class OneHotEncoder(InvertibleTableTransformer):
         # Maps nan values (str of old column) to corresponding new column name
         self._value_to_column_nans: dict[str, str] | None = None
 
-    # noinspection PyProtectedMember
     def fit(self, table: Table, column_names: list[str] | None) -> OneHotEncoder:
         """
         Learn a transformation for a set of columns in a table.
@@ -150,7 +149,6 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         return result
 
-    # noinspection PyProtectedMember
     def transform(self, table: Table) -> Table:
         """
         Apply the learned transformation to a table.
@@ -238,7 +236,6 @@ class OneHotEncoder(InvertibleTableTransformer):
         # Apply sorting and return:
         return table.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
-    # noinspection PyProtectedMember
     def inverse_transform(self, transformed_table: Table) -> Table:
         """
         Undo the learned transformation.

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -49,7 +49,7 @@ class OneHotEncoder(InvertibleTableTransformer):
     >>> from safeds.data.tabular.transformation import OneHotEncoder
     >>> table = Table({"col1": ["a", "b", "c", "a"]})
     >>> transformer = OneHotEncoder()
-    >>> transformer.fit_and_transform(table, ["col1"])
+    >>> transformer.fit_and_transform(table, ["col1"])[1]
        col1__a  col1__b  col1__c
     0      1.0      0.0      0.0
     1      0.0      1.0      0.0

--- a/tests/safeds/data/tabular/transformation/test_discretizer.py
+++ b/tests/safeds/data/tabular/transformation/test_discretizer.py
@@ -197,13 +197,15 @@ class TestFitAndTransform:
         ],
         ids=["None", "col1"],
     )
-    def test_should_return_transformed_table(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
         table: Table,
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        assert Discretizer().fit_and_transform(table, column_names) == expected
+        fitted_transformer, transformed_table = Discretizer().fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     @pytest.mark.parametrize(
         ("table", "number_of_bins", "expected"),
@@ -243,7 +245,9 @@ class TestFitAndTransform:
         number_of_bins: int,
         expected: Table,
     ) -> None:
-        assert Discretizer(number_of_bins).fit_and_transform(table, ["col1"]) == expected
+        fitted_transformer, transformed_table = Discretizer(number_of_bins).fit_and_transform(table, ["col1"])
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table(

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -413,7 +413,7 @@ class TestFitAndTransform:
             "other value to replace",
         ],
     )
-    def test_should_return_transformed_table(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
         table: Table,
         column_names: list[str] | None,
@@ -421,21 +421,19 @@ class TestFitAndTransform:
         value_to_replace: float | str | None,
         expected: Table,
     ) -> None:
-        if isinstance(strategy, _Mode):
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    action="ignore",
-                    message=r"There are multiple most frequent values in a column given to the Imputer\..*",
-                    category=UserWarning,
-                )
-                assert (
-                    Imputer(strategy, value_to_replace=value_to_replace).fit_and_transform(table, column_names)
-                    == expected
-                )
-        else:
-            assert (
-                Imputer(strategy, value_to_replace=value_to_replace).fit_and_transform(table, column_names) == expected
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                message=r"There are multiple most frequent values in a column given to the Imputer\..*",
+                category=UserWarning,
             )
+            fitted_transformer, transformed_table = Imputer(
+                strategy,
+                value_to_replace=value_to_replace,
+            ).fit_and_transform(table, column_names)
+
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)
     def test_should_not_change_original_table(self, strategy: Imputer.Strategy) -> None:

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -132,13 +132,15 @@ class TestFitAndTransform:
         ],
         ids=["no_column_names", "with_column_names"],
     )
-    def test_should_return_transformed_table(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
         table: Table,
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        assert LabelEncoder().fit_and_transform(table, column_names) == expected
+        fitted_transformer, transformed_table = LabelEncoder().fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table(

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -263,13 +263,15 @@ class TestFitAndTransform:
             "column with nans",
         ],
     )
-    def test_should_return_transformed_table(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
         table: Table,
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        assert OneHotEncoder().fit_and_transform(table, column_names) == expected
+        fitted_transformer, transformed_table = OneHotEncoder().fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table(

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -194,7 +194,9 @@ class TestFitAndTransform:
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        fitted_transformer, transformed_table = RangeScaler(minimum=-10.0, maximum=10.0).fit_and_transform(table, column_names)
+        fitted_transformer, transformed_table = RangeScaler(minimum=-10.0, maximum=10.0).fit_and_transform(
+            table, column_names,
+        )
         assert fitted_transformer.is_fitted
         assert transformed_table == expected
 

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -144,13 +144,15 @@ class TestFitAndTransform:
         ],
         ids=["one_column", "two_columns"],
     )
-    def test_should_return_transformed_table(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
         table: Table,
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        assert RangeScaler().fit_and_transform(table, column_names) == expected
+        fitted_transformer, transformed_table = RangeScaler().fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     @pytest.mark.parametrize(
         ("table", "column_names", "expected"),
@@ -186,13 +188,15 @@ class TestFitAndTransform:
         ],
         ids=["one_column", "two_columns"],
     )
-    def test_should_return_transformed_table_with_correct_range(
+    def test_should_return_fitted_transformer_and_transformed_table_with_correct_range(
         self,
         table: Table,
         column_names: list[str] | None,
         expected: Table,
     ) -> None:
-        assert RangeScaler(minimum=-10.0, maximum=10.0).fit_and_transform(table, column_names) == expected
+        fitted_transformer, transformed_table = RangeScaler(minimum=-10.0, maximum=10.0).fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert transformed_table == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table(

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -195,7 +195,8 @@ class TestFitAndTransform:
         expected: Table,
     ) -> None:
         fitted_transformer, transformed_table = RangeScaler(minimum=-10.0, maximum=10.0).fit_and_transform(
-            table, column_names,
+            table,
+            column_names,
         )
         assert fitted_transformer.is_fitted
         assert transformed_table == expected

--- a/tests/safeds/data/tabular/transformation/test_standard_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_standard_scaler.py
@@ -111,21 +111,15 @@ class TestIsFitted:
         assert fitted_transformer.is_fitted
 
 
-class TestFitAndTransformOnMultipleTables:
+class TestFitAndTransform:
     @pytest.mark.parametrize(
-        ("fit_and_transform_table", "only_transform_table", "column_names", "expected_1", "expected_2"),
+        ("table", "column_names", "expected"),
         [
             (
                 Table(
                     {
                         "col1": [0.0, 0.0, 1.0, 1.0],
                         "col2": [0.0, 0.0, 1.0, 1.0],
-                    },
-                ),
-                Table(
-                    {
-                        "col1": [2],
-                        "col2": [2],
                     },
                 ),
                 None,
@@ -135,30 +129,20 @@ class TestFitAndTransformOnMultipleTables:
                         "col2": [-1.0, -1.0, 1.0, 1.0],
                     },
                 ),
-                Table(
-                    {
-                        "col1": [3.0],
-                        "col2": [3.0],
-                    },
-                ),
             ),
         ],
         ids=["two_columns"],
     )
-    def test_should_return_transformed_tables(
+    def test_should_return_fitted_transformer_and_transformed_table(
         self,
-        fit_and_transform_table: Table,
-        only_transform_table: Table,
+        table: Table,
         column_names: list[str] | None,
-        expected_1: Table,
-        expected_2: Table,
+        expected: Table,
     ) -> None:
-        s = StandardScaler().fit(fit_and_transform_table, column_names)
-        assert s.fit_and_transform(fit_and_transform_table, column_names) == expected_1
-        assert s.transform(only_transform_table) == expected_2
+        fitted_transformer, transformed_table = StandardScaler().fit_and_transform(table, column_names)
+        assert fitted_transformer.is_fitted
+        assert_that_tables_are_close(transformed_table, expected)
 
-
-class TestFitAndTransform:
     def test_should_not_change_original_table(self) -> None:
         table = Table(
             {

--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -1,9 +1,16 @@
 import itertools
 
 import pytest
-
 from safeds.data.tabular.containers import Table
-from safeds.data.tabular.transformation import TableTransformer, StandardScaler, RangeScaler, OneHotEncoder, LabelEncoder, Discretizer, Imputer
+from safeds.data.tabular.transformation import (
+    Discretizer,
+    Imputer,
+    LabelEncoder,
+    OneHotEncoder,
+    RangeScaler,
+    StandardScaler,
+    TableTransformer,
+)
 
 
 def transformers_numeric() -> list[TableTransformer]:
@@ -21,7 +28,7 @@ def transformers_numeric() -> list[TableTransformer]:
     return [
         StandardScaler(),
         RangeScaler(),
-        Discretizer()
+        Discretizer(),
     ]
 
 
@@ -39,7 +46,7 @@ def transformers_non_numeric() -> list[TableTransformer]:
     """
     return [
         OneHotEncoder(),
-        LabelEncoder()
+        LabelEncoder(),
     ]
 
 
@@ -56,7 +63,7 @@ def transformers() -> list[TableTransformer]:
         The list of all transformers to test.
     """
     return transformers_numeric() + transformers_non_numeric() + [
-        Imputer(strategy=Imputer.Strategy.Mode())
+        Imputer(strategy=Imputer.Strategy.Mode()),
     ]
 
 

--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -105,7 +105,9 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_same_hash_for_equal_transformer(
-        self, transformer1: TableTransformer, transformer2: TableTransformer,
+        self,
+        transformer1: TableTransformer,
+        transformer2: TableTransformer,
     ) -> None:
         assert hash(transformer1) == hash(transformer2)
 
@@ -115,20 +117,26 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_unequal_transformer(
-        self, transformer1: TableTransformer, transformer2: TableTransformer,
+        self,
+        transformer1: TableTransformer,
+        transformer2: TableTransformer,
     ) -> None:
         assert hash(transformer1) != hash(transformer2)
 
     @pytest.mark.parametrize("transformer1", transformers_numeric(), ids=lambda x: x.__class__.__name__)
     def test_should_return_different_hash_for_same_numeric_transformer_fit(
-        self, transformer1: TableTransformer, valid_data_numeric: Table,
+        self,
+        transformer1: TableTransformer,
+        valid_data_numeric: Table,
     ) -> None:
         transformer1_fit = transformer1.fit(valid_data_numeric, ["col1"])
         assert hash(transformer1) != hash(transformer1_fit)
 
     @pytest.mark.parametrize("transformer1", transformers_non_numeric(), ids=lambda x: x.__class__.__name__)
     def test_should_return_different_hash_for_same_non_numeric_transformer_fit(
-        self, transformer1: TableTransformer, valid_data_non_numeric: Table,
+        self,
+        transformer1: TableTransformer,
+        valid_data_non_numeric: Table,
     ) -> None:
         transformer1_fit = transformer1.fit(valid_data_non_numeric, ["col1"])
         assert hash(transformer1) != hash(transformer1_fit)
@@ -139,7 +147,10 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_numeric_transformer_fit(
-        self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_numeric: Table,
+        self,
+        transformer1: TableTransformer,
+        transformer2: TableTransformer,
+        valid_data_numeric: Table,
     ) -> None:
         transformer1_fit = transformer1.fit(valid_data_numeric, ["col1"])
         assert hash(transformer2) != hash(transformer1_fit)
@@ -150,14 +161,19 @@ class TestHash:
         ids=lambda x: x.__class__.__name__,
     )
     def test_should_return_different_hash_for_non_numeric_transformer_fit(
-        self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_non_numeric: Table,
+        self,
+        transformer1: TableTransformer,
+        transformer2: TableTransformer,
+        valid_data_non_numeric: Table,
     ) -> None:
         transformer1_fit = transformer1.fit(valid_data_non_numeric, ["col1"])
         assert hash(transformer2) != hash(transformer1_fit)
 
     @pytest.mark.parametrize("transformer2", transformers(), ids=lambda x: x.__class__.__name__)
     def test_should_return_different_hash_for_imputer_fit(
-        self, transformer2: TableTransformer, valid_data_imputer: Table,
+        self,
+        transformer2: TableTransformer,
+        valid_data_imputer: Table,
     ) -> None:
         transformer1 = Imputer(strategy=Imputer.Strategy.Mode())
         transformer1_fit = transformer1.fit(valid_data_imputer, ["col1"])

--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -62,9 +62,13 @@ def transformers() -> list[TableTransformer]:
     classifiers : list[TableTransformer]
         The list of all transformers to test.
     """
-    return transformers_numeric() + transformers_non_numeric() + [
-        Imputer(strategy=Imputer.Strategy.Mode()),
-    ]
+    return (
+        transformers_numeric()
+        + transformers_non_numeric()
+        + [
+            Imputer(strategy=Imputer.Strategy.Mode()),
+        ]
+    )
 
 
 @pytest.fixture()
@@ -84,6 +88,7 @@ def valid_data_non_numeric() -> Table:
         },
     )
 
+
 @pytest.fixture()
 def valid_data_imputer() -> Table:
     return Table(
@@ -94,36 +99,66 @@ def valid_data_imputer() -> Table:
 
 
 class TestHash:
-    @pytest.mark.parametrize(("transformer1", "transformer2"), ([(x, y) for x in transformers() for y in transformers() if x.__class__ == y.__class__]), ids=lambda x: x.__class__.__name__)
-    def test_should_return_same_hash_for_equal_transformer(self, transformer1: TableTransformer, transformer2: TableTransformer) -> None:
+    @pytest.mark.parametrize(
+        ("transformer1", "transformer2"),
+        ([(x, y) for x in transformers() for y in transformers() if x.__class__ == y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_same_hash_for_equal_transformer(
+        self, transformer1: TableTransformer, transformer2: TableTransformer,
+    ) -> None:
         assert hash(transformer1) == hash(transformer2)
 
-    @pytest.mark.parametrize(("transformer1", "transformer2"), ([(x, y) for x in transformers() for y in transformers() if x.__class__ != y.__class__]), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_unequal_transformer(self, transformer1: TableTransformer, transformer2: TableTransformer) -> None:
+    @pytest.mark.parametrize(
+        ("transformer1", "transformer2"),
+        ([(x, y) for x in transformers() for y in transformers() if x.__class__ != y.__class__]),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_unequal_transformer(
+        self, transformer1: TableTransformer, transformer2: TableTransformer,
+    ) -> None:
         assert hash(transformer1) != hash(transformer2)
 
     @pytest.mark.parametrize("transformer1", transformers_numeric(), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_same_numeric_transformer_fit(self, transformer1: TableTransformer, valid_data_numeric: Table) -> None:
+    def test_should_return_different_hash_for_same_numeric_transformer_fit(
+        self, transformer1: TableTransformer, valid_data_numeric: Table,
+    ) -> None:
         transformer1_fit = transformer1.fit(valid_data_numeric, ["col1"])
         assert hash(transformer1) != hash(transformer1_fit)
 
     @pytest.mark.parametrize("transformer1", transformers_non_numeric(), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_same_non_numeric_transformer_fit(self, transformer1: TableTransformer, valid_data_non_numeric: Table) -> None:
+    def test_should_return_different_hash_for_same_non_numeric_transformer_fit(
+        self, transformer1: TableTransformer, valid_data_non_numeric: Table,
+    ) -> None:
         transformer1_fit = transformer1.fit(valid_data_non_numeric, ["col1"])
         assert hash(transformer1) != hash(transformer1_fit)
 
-    @pytest.mark.parametrize(("transformer1", "transformer2"), (list(itertools.product(transformers_numeric(), transformers()))), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_numeric_transformer_fit(self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_numeric: Table) -> None:
+    @pytest.mark.parametrize(
+        ("transformer1", "transformer2"),
+        (list(itertools.product(transformers_numeric(), transformers()))),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_numeric_transformer_fit(
+        self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_numeric: Table,
+    ) -> None:
         transformer1_fit = transformer1.fit(valid_data_numeric, ["col1"])
         assert hash(transformer2) != hash(transformer1_fit)
 
-    @pytest.mark.parametrize(("transformer1", "transformer2"), (list(itertools.product(transformers_non_numeric(), transformers()))), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_non_numeric_transformer_fit(self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_non_numeric: Table) -> None:
+    @pytest.mark.parametrize(
+        ("transformer1", "transformer2"),
+        (list(itertools.product(transformers_non_numeric(), transformers()))),
+        ids=lambda x: x.__class__.__name__,
+    )
+    def test_should_return_different_hash_for_non_numeric_transformer_fit(
+        self, transformer1: TableTransformer, transformer2: TableTransformer, valid_data_non_numeric: Table,
+    ) -> None:
         transformer1_fit = transformer1.fit(valid_data_non_numeric, ["col1"])
         assert hash(transformer2) != hash(transformer1_fit)
 
     @pytest.mark.parametrize("transformer2", transformers(), ids=lambda x: x.__class__.__name__)
-    def test_should_return_different_hash_for_imputer_fit(self, transformer2: TableTransformer, valid_data_imputer: Table) -> None:
+    def test_should_return_different_hash_for_imputer_fit(
+        self, transformer2: TableTransformer, valid_data_imputer: Table,
+    ) -> None:
         transformer1 = Imputer(strategy=Imputer.Strategy.Mode())
         transformer1_fit = transformer1.fit(valid_data_imputer, ["col1"])
         assert hash(transformer2) != hash(transformer1_fit)


### PR DESCRIPTION
Closes #613

### Summary of Changes

`TableTransformer.fit_and_transform` now returns a tuple containing
* the fitted transformer
* the transformed table.
