### PR TITLE
feat: deprecated `Table.from_excel_file` and `Table.to_excel_file`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -124,6 +124,10 @@ class Table:
 
         Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
 
+        !!! warning "Deprecated"
+            Convert your data to a CSV file and use
+            [Table.from_csv_file][safeds.data.tabular.containers._table.Table.from_csv_file] instead.
+
         Parameters
         ----------
         path:
@@ -150,6 +154,13 @@ class Table:
         1  2  5
         2  3  6
         """
+        warnings.warn(
+            "This method is deprecated and will be removed in a future version. "
+            "Convert your data to a CSV file and use `Table.from_csv_file` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         import pandas as pd
 
         path = Path(path)
@@ -2357,6 +2368,9 @@ class Table:
         If the file and/or the directories do not exist, they will be created. If the file already exists, it will be
         overwritten.
 
+        !!! warning "Deprecated"
+            Use [`to_csv_file`][safeds.data.tabular.containers._table.Table.to_csv_file] instead.
+
         Parameters
         ----------
         path:
@@ -2373,6 +2387,12 @@ class Table:
         >>> table = Table.from_dict({"a": [1, 2, 3], "b": [4, 5, 6]})
         >>> table.to_excel_file("./src/resources/to_excel_file.xlsx")
         """
+        warnings.warn(
+            "This method is deprecated and will be removed in a future version. Use `Table.to_csv_file` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         import openpyxl
 
         path = Path(path)


### PR DESCRIPTION
Closes #727

### Summary of Changes

* Deprecate `Table.from_excel_file`.
* Deprecate `Table.to_excel_file`.