### PR TITLE
feat: add continuous prediction to output conversion

### DIFF
--- a/src/safeds/data/labeled/containers/_time_series_dataset.py
+++ b/src/safeds/data/labeled/containers/_time_series_dataset.py
@@ -178,10 +178,9 @@ class TimeSeriesDataset:
         """
         return self._table
 
-    def _into_dataloader_with_window(self, window_size: int,
-                                     forecast_horizon: int,
-                                     batch_size: int,
-                                     continues: bool = False) -> DataLoader:
+    def _into_dataloader_with_window(
+        self, window_size: int, forecast_horizon: int, batch_size: int, continues: bool = False
+    ) -> DataLoader:
         """
         Return a Dataloader for the data stored in this time series, used for training neural networks.
 
@@ -233,7 +232,7 @@ class TimeSeriesDataset:
         # -> [i, win_size],[target]
         feature_cols = self.features.to_columns()
         for i in range(size - (forecast_horizon + window_size)):
-            window = target_tensor[i: i + window_size]
+            window = target_tensor[i : i + window_size]
             if continues:
                 label = target_tensor[i + window_size : i + window_size + forecast_horizon]
             else:

--- a/src/safeds/ml/nn/_input_conversion_time_series.py
+++ b/src/safeds/ml/nn/_input_conversion_time_series.py
@@ -16,6 +16,7 @@ class InputConversionTimeSeries(InputConversion[TimeSeriesDataset, TimeSeriesDat
         self,
         window_size: int,
         forecast_horizon: int,
+        continues: bool = False,
     ) -> None:
         """
         Define the input parameters for the neural network in the input conversion.
@@ -33,6 +34,7 @@ class InputConversionTimeSeries(InputConversion[TimeSeriesDataset, TimeSeriesDat
         self._target_name: str = ""
         self._time_name: str = ""
         self._feature_names: list[str] = []
+        self._continues: bool = continues
 
     @property
     def _data_size(self) -> int:
@@ -58,6 +60,7 @@ class InputConversionTimeSeries(InputConversion[TimeSeriesDataset, TimeSeriesDat
             self._window_size,
             self._forecast_horizon,
             batch_size,
+            continues=self._continues
         )
 
     def _data_conversion_predict(self, input_data: TimeSeriesDataset, batch_size: int) -> DataLoader:

--- a/src/safeds/ml/nn/_input_conversion_time_series.py
+++ b/src/safeds/ml/nn/_input_conversion_time_series.py
@@ -57,10 +57,7 @@ class InputConversionTimeSeries(InputConversion[TimeSeriesDataset, TimeSeriesDat
     ) -> DataLoader:
         self._num_of_classes = num_of_classes
         return input_data._into_dataloader_with_window(
-            self._window_size,
-            self._forecast_horizon,
-            batch_size,
-            continues=self._continues
+            self._window_size, self._forecast_horizon, batch_size, continues=self._continues
         )
 
     def _data_conversion_predict(self, input_data: TimeSeriesDataset, batch_size: int) -> DataLoader:

--- a/src/safeds/ml/nn/_output_conversion_time_series.py
+++ b/src/safeds/ml/nn/_output_conversion_time_series.py
@@ -67,7 +67,7 @@ class OutputConversionTimeSeries(OutputConversion[TimeSeriesDataset, TimeSeriesD
         self._prediction_name = prediction_name
 
     def _data_conversion(self, input_data: TimeSeriesDataset, output_data: Tensor, **kwargs: Any) -> TimeSeriesDataset:
-        import numpy as np
+
         if "window_size" not in kwargs or not isinstance(kwargs.get("window_size"), int):
             raise ValueError(
                 "The window_size is not set. The data can only be converted if the window_size is provided as `int` in the kwargs.",
@@ -79,19 +79,17 @@ class OutputConversionTimeSeries(OutputConversion[TimeSeriesDataset, TimeSeriesD
         window_size: int = kwargs["window_size"]
         forecast_horizon: int = kwargs["forecast_horizon"]
         input_data_table = input_data.to_table()
-        input_data_table = Table.from_rows(input_data_table.to_rows()[window_size + forecast_horizon:])
+        input_data_table = Table.from_rows(input_data_table.to_rows()[window_size + forecast_horizon :])
         transposed_data = output_data.t()
         data = transposed_data.tolist()
         col_list: List[Column] = []
         if isinstance(data[0], list):
             for index, col in enumerate(data):
-                col_list.append(Column(self._prediction_name + " "+str(index), col))
+                col_list.append(Column(self._prediction_name + " " + str(index), col))
         else:
             col_list.append(Column(self._prediction_name + " 0", data))
 
-        return input_data_table.add_columns(
-            col_list
-        ).to_time_series_dataset(
+        return input_data_table.add_columns(col_list).to_time_series_dataset(
             target_name=self._prediction_name + " 0",
             time_name=input_data.time.name,
             extra_names=input_data.extras.column_names,

--- a/src/safeds/ml/nn/_output_conversion_time_series.py
+++ b/src/safeds/ml/nn/_output_conversion_time_series.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List
 
 from safeds._utils import _structural_hash
 
@@ -82,7 +82,7 @@ class OutputConversionTimeSeries(OutputConversion[TimeSeriesDataset, TimeSeriesD
         input_data_table = Table.from_rows(input_data_table.to_rows()[window_size + forecast_horizon:])
         transposed_data = output_data.t()
         data = transposed_data.tolist()
-        col_list = []
+        col_list: List[Column] = []
         if isinstance(data[0], list):
             for index, col in enumerate(data):
                 col_list.append(Column(self._prediction_name + " "+str(index), col))

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
@@ -219,8 +219,9 @@ def test_should_create_dataloader_predict_invalid(
 
 
 def test_continues_dataloader() -> None:
-    ts = (Table({"a": [1, 2, 3, 4, 5, 6, 7], "b": [1, 2, 3, 4, 5, 6, 7], "c": [1, 2, 3, 4, 5, 6, 7]}).
-          to_time_series_dataset("a", "b"))
+    ts = Table(
+        {"a": [1, 2, 3, 4, 5, 6, 7], "b": [1, 2, 3, 4, 5, 6, 7], "c": [1, 2, 3, 4, 5, 6, 7]}
+    ).to_time_series_dataset("a", "b")
     dl = ts._into_dataloader_with_window(1, 2, 1, True)
     dl_2 = ts._into_dataloader_with_window(1, 2, 1, False)
     assert len(dl_2.dataset.Y) == len(dl.dataset.Y)

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
@@ -6,6 +6,7 @@ from torch.types import Device
 from safeds._config import _get_device
 from safeds.data.tabular.containers import Table
 from safeds.data.labeled.containers import TimeSeriesDataset
+import torch
 from torch.utils.data import DataLoader
 
 from safeds.exceptions import OutOfBoundsError
@@ -215,3 +216,13 @@ def test_should_create_dataloader_predict_invalid(
         data._into_dataloader_with_window_predict(
             window_size=window_size, forecast_horizon=forecast_horizon, batch_size=1
         )
+
+
+def test_continues_dataloader():
+    ts = (Table({"a": [1, 2, 3, 4, 5, 6, 7], "b": [1, 2, 3, 4, 5, 6, 7], "c": [1, 2, 3, 4, 5, 6, 7]}).
+          to_time_series_dataset("a", "b"))
+    dl = ts._into_dataloader_with_window(1, 2, 1, True)
+    dl_2 = ts._into_dataloader_with_window(1, 2, 1, False)
+    assert len(dl_2.dataset.Y) == len(dl.dataset.Y)
+    # 4mal 2er Arrays mit 1er Einträgen
+    assert dl.dataset.Y.shape == torch.Size([4, 2, 1])

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_into_dataloader.py
@@ -218,7 +218,7 @@ def test_should_create_dataloader_predict_invalid(
         )
 
 
-def test_continues_dataloader():
+def test_continues_dataloader() -> None:
     ts = (Table({"a": [1, 2, 3, 4, 5, 6, 7], "b": [1, 2, 3, 4, 5, 6, 7], "c": [1, 2, 3, 4, 5, 6, 7]}).
           to_time_series_dataset("a", "b"))
     dl = ts._into_dataloader_with_window(1, 2, 1, True)

--- a/tests/safeds/ml/nn/test_lstm_workflow.py
+++ b/tests/safeds/ml/nn/test_lstm_workflow.py
@@ -40,5 +40,5 @@ def test_lstm_model(device: Device) -> None:
     trained_model_2 = model_2.fit(train_table.to_time_series_dataset("value", "date"), epoch_size=1)
 
     trained_model.predict(test_table.to_time_series_dataset("value", "date"))
-    trained_model_2.predict(test_table.to_time_series_dataset("value", "date")).to_table()
+    trained_model_2.predict(test_table.to_time_series_dataset("value", "date"))
     assert model._model.state_dict()["_pytorch_layers.0._layer.weight"].device == _get_device()

--- a/tests/safeds/ml/nn/test_lstm_workflow.py
+++ b/tests/safeds/ml/nn/test_lstm_workflow.py
@@ -31,7 +31,14 @@ def test_lstm_model(device: Device) -> None:
         [ForwardLayer(input_size=7, output_size=256), LSTMLayer(input_size=256, output_size=1)],
         OutputConversionTimeSeries("predicted"),
     )
+    model_2 = NeuralNetworkRegressor(
+        InputConversionTimeSeries(window_size=7, forecast_horizon=12, continues=True),
+        [ForwardLayer(input_size=7, output_size=256), LSTMLayer(input_size=256, output_size=12)],
+        OutputConversionTimeSeries("predicted"),
+    )
     trained_model = model.fit(train_table.to_time_series_dataset("value", "date"), epoch_size=1)
+    trained_model_2 = model_2.fit(train_table.to_time_series_dataset("value", "date"), epoch_size=1)
 
     trained_model.predict(test_table.to_time_series_dataset("value", "date"))
+    trained_model_2.predict(test_table.to_time_series_dataset("value", "date")).to_table()
     assert model._model.state_dict()["_pytorch_layers.0._layer.weight"].device == _get_device()


### PR DESCRIPTION
Closes #740 

### Summary of Changes

<!-- Please provide a summary of changes in this pull request, ensuring all changes are explained. -->
I added a continues prediction for time series.

As example w.o. continues:
we want to predict values with forecast horizon 3, we only predict one value with 3 steps into the future.
With continues, all values until the forecast horizon (forecast horizon is included) will be predicted. This brought one problem up, as we don't store list values in our Columns. So I decided to make a new column for every step in the forecast horizon. 
so with 3 there will be 3 prediction columns: prediction 0, prediction 1, prediction 2

Any Ideas on this behavior? @lars-reimann @Marsmaennchen221 @sibre28 