### PR TITLE
fix: test_slice_rows and fix_test_split_rows

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1391,7 +1391,7 @@ class Table:
         self,
         percentage_in_first: float,
         *,
-        shuffle: bool = True,
+        shuffle: bool = False,
     ) -> tuple[Table, Table]:
         """
         Create two tables by splitting the rows of the current table.
@@ -1454,9 +1454,8 @@ class Table:
 
         input_table = self.shuffle_rows() if shuffle else self
         number_of_rows_in_first = round(percentage_in_first * input_table.number_of_rows)
-
         return (
-            input_table.slice_rows(length=number_of_rows_in_first),
+            input_table.slice_rows(start=0, length=number_of_rows_in_first),
             input_table.slice_rows(start=number_of_rows_in_first),
         )
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1391,7 +1391,7 @@ class Table:
         self,
         percentage_in_first: float,
         *,
-        shuffle: bool = False,
+        shuffle: bool = True,
     ) -> tuple[Table, Table]:
         """
         Create two tables by splitting the rows of the current table.

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -9,7 +9,7 @@ from safeds.exceptions import IndexOutOfBoundsError
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
             Table({"col1": [1, 2], "col2": [1, 2]}),
-            Table({"col1": [1, 2, 1], "col2": [1, 2,4]}),
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
         ),
     ],
     ids=["Table with three rows"],

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -9,7 +9,7 @@ from safeds.exceptions import IndexOutOfBoundsError
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
             Table({"col1": [1, 2], "col2": [1, 2]}),
-            Table({"col1": [1, 1], "col2": [1, 4]}),
+            Table({"col1": [1, 2, 1], "col2": [1, 2,4]}),
         ),
     ],
     ids=["Table with three rows"],

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -33,6 +33,8 @@ def test_should_split_table(
     percentage_in_first: int,
 ) -> None:
     train_table, test_table = table.split_rows(percentage_in_first)
+    print(result_train_table.schema)
+    #print(train_table.schema)
     assert result_test_table == test_table
     assert result_train_table.schema == train_table.schema
     assert result_train_table == train_table

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -1,5 +1,6 @@
 import pytest
 from safeds.data.tabular.containers import Table
+from safeds.data.tabular.typing import Schema
 
 
 @pytest.mark.parametrize(
@@ -7,20 +8,20 @@ from safeds.data.tabular.containers import Table
     [
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-            Table({"col1": [1, 2], "col2": [1, 2]}),
-            Table({"col1": [1], "col2": [4]}),
+            Table({"col1": [1, 2], "col2": [4, 2]}),
+            Table({"col1": [1], "col2": [1]}),
             2 / 3,
         ),
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-            Table(),
-            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Table({"col1": [], "col2": []}),
+            Table({"col1": [1, 2, 1], "col2": [4, 2, 1]}),
             0,
         ),
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-            Table(),
+            Table({"col1": [1, 2, 1], "col2": [4, 2, 1]}),
+            Table({"col1": [], "col2": []}),
             1,
         ),
     ],
@@ -32,11 +33,11 @@ def test_should_split_table(
     result_train_table: Table,
     percentage_in_first: int,
 ) -> None:
+    #test if schema stayed the same
+    schema = table.schema
     train_table, test_table = table.split_rows(percentage_in_first)
-    print(result_train_table.schema)
-    #print(train_table.schema)
     assert result_test_table == test_table
-    assert result_train_table.schema == train_table.schema
+    assert schema == train_table.schema
     assert result_train_table == train_table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from safeds.data.tabular.containers import Table
 
@@ -41,16 +43,17 @@ def test_should_split_table(
 
 
 @pytest.mark.parametrize(
-    "percentage_in_first",
+    ("percentage_in_first", "error_msg"),
     [
-        -1.0,
-        2.0,
+        (-1.0, re.escape("percentage_in_first must be in [0, 1] but was -1.0.")),
+        (2.0, re.escape("percentage_in_first must be in [0, 1] but was 2.0.")),
     ],
     ids=["-100%", "200%"],
 )
-def test_should_raise_if_value_not_in_range(percentage_in_first: float) -> None:
+def test_should_raise_if_value_not_in_range(percentage_in_first: float, error_msg: str) -> None:
+    from safeds.exceptions import OutOfBoundsError
     table = Table({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    with pytest.raises(ValueError, match=r"is not inside \[0, 1\]"):
+    with pytest.raises(OutOfBoundsError, match=error_msg):
         table.split_rows(percentage_in_first)
 
 


### PR DESCRIPTION


### Summary of Changes

<!-- Please provide a summary of changes in this pull request, ensuring all changes are explained. -->
fixing the split row tests

right now, shuffle is default true, is this wanted?
Also, a empty Table created from a slice rows operation has the same schema, as the table before, so not an empty schema. Is this behavior wanted?
@lars-reimann 
