### PR TITLE
fix: 'Table.summarize_statistics()' fixed

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1057,7 +1057,6 @@ class Column(Sequence[T_co]):
             return 1.0  # All non-null values are the same (since there is are none)
         if type(non_missing.dtype)==pl.datatypes.Boolean: 
             non_missing = non_missing.cast(str)
-            print(non_missing)
         mode_count = non_missing.unique_counts().max()
 
         return mode_count / non_missing.len()

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1051,10 +1051,13 @@ class Column(Sequence[T_co]):
         >>> column.stability()
         0.5
         """
+        import polars as pl
         non_missing = self._series.drop_nulls()
         if non_missing.len() == 0:
             return 1.0  # All non-null values are the same (since there is are none)
-
+        if type(non_missing.dtype)==pl.datatypes.Boolean: 
+            non_missing = non_missing.cast(str)
+            print(non_missing)
         mode_count = non_missing.unique_counts().max()
 
         return mode_count / non_missing.len()

--- a/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
@@ -110,12 +110,43 @@ from safeds.data.tabular.containers import Table
                 },
             ),
         ),
+        (
+            Table({"col": [True, False, True]}),
+            Table(
+                {
+                    "metric": [
+                        "min",
+                        "max",
+                        "mean",
+                        "median",
+                        "standard deviation",
+                        "distinct value count",
+                        "idness",
+                        "missing value ratio",
+                        "stability",
+                    ],
+                    "col": [
+                        "-",
+                        "True",
+                        "-",
+                        "-",
+                        "-",
+                        "2",
+                        "0.6666666666666666",
+                        "0.0",
+                        "0.6666666666666666",
+                    ],
+                },
+            ),
+
+        )
     ],
     ids=[
         "Column of integers and Column of characters",
         "empty",
         "empty with columns",
         "Column of None",
+        "Column of booleans",
     ],
 )
 def test_should_summarize_statistics(table: Table, expected: Table) -> None:


### PR DESCRIPTION
### Summary of Changes

cast the pl.series to str when its filled with bools when calculating variance.
This is needed because it can't get unique_counts from bools
