### PR TITLE
fix: handling of boolean columns in column statistics

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -688,9 +688,12 @@ class Column(Sequence[T_co]):
                 self.stability(),
             ]
         else:
+            min_ = self.min()
+            max_ = self.max()
+
             values = [
-                str(self.min() or "-"),
-                str(self.max() or "-"),
+                str("-" if min_ is None else min_),
+                str("-" if max_ is None else max_),
                 "-",
                 "-",
                 "-",

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1058,7 +1058,8 @@ class Column(Sequence[T_co]):
         if non_missing.len() == 0:
             return 1.0  # All non-null values are the same (since there is are none)
 
-        mode_count = non_missing.unique_counts().max()
+        # `unique_counts` crashes in polars for boolean columns
+        mode_count = non_missing.value_counts().get_column("count").max()
 
         return mode_count / non_missing.len()
 

--- a/tests/safeds/data/tabular/containers/_column/test_stability.py
+++ b/tests/safeds/data/tabular/containers/_column/test_stability.py
@@ -12,6 +12,7 @@ from safeds.data.tabular.containers import Column
         ([None], 1),
         ([1, 2, 3, 4], 1 / 4),
         (["b", "a", "abc", "abc", "abc"], 3 / 5),
+        ([True, False, True, True, None], 3 / 4),
     ],
     ids=[
         "empty",
@@ -19,6 +20,7 @@ from safeds.data.tabular.containers import Column
         "only missing values",
         "numeric",
         "non-numeric",
+        "boolean",  # caused a crash in previous implementation
     ],
 )
 def test_should_return_stability_of_column(values: list[Any], expected: float) -> None:

--- a/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_column/test_summarize_statistics.py
@@ -7,7 +7,36 @@ from safeds.data.tabular.containers import Column, Table
 @pytest.mark.parametrize(
     ("column", "expected"),
     [
-        (
+        (  # boolean
+            Column("col", [True, False, True]),
+            Table(
+                {
+                    "metric": [
+                        "min",
+                        "max",
+                        "mean",
+                        "median",
+                        "standard deviation",
+                        "distinct value count",
+                        "idness",
+                        "missing value ratio",
+                        "stability",
+                    ],
+                    "col": [
+                        "False",
+                        "True",
+                        "-",
+                        "-",
+                        "-",
+                        "2",
+                        str(2 / 3),
+                        "0.0",
+                        str(2 / 3),
+                    ],
+                },
+            ),
+        ),
+        (  # ints
             Column("col", [1, 2, 1]),
             Table(
                 {
@@ -25,18 +54,18 @@ from safeds.data.tabular.containers import Column, Table
                     "col": [
                         1,
                         2,
-                        4.0 / 3,
-                        1.0,
+                        4 / 3,
+                        1,
                         stdev([1, 2, 1]),
                         2,
-                        2.0 / 3,
-                        0.0,
-                        2.0 / 3,
+                        2 / 3,
+                        0,
+                        2 / 3,
                     ],
                 },
             ),
         ),
-        (
+        (  # strings
             Column("col", ["a", "b", "c"]),
             Table(
                 {
@@ -65,7 +94,7 @@ from safeds.data.tabular.containers import Column, Table
                 },
             ),
         ),
-        (
+        (  # only missing
             Column("col", [None, None]),
             Table(
                 {
@@ -96,9 +125,10 @@ from safeds.data.tabular.containers import Column, Table
         ),
     ],
     ids=[
-        "Column of ints",
-        "Column of strings",
-        "Column of None",
+        "boolean",
+        "ints",
+        "strings",
+        "only missing",
     ],
 )
 def test_should_summarize_statistics(column: Column, expected: Table) -> None:


### PR DESCRIPTION
### Summary of Changes

* `False` (or any falsy non-numeric value) was replaced by `-` in `summarize_statistics` for min/max. It's now displayed properly.
* `stability` could not be computed for boolean columns (polars ComputeError). This is fixed.
