### PR TITLE
feat: add FunctionalTableTransformer

### DIFF
--- a/docs/tutorials/regression.ipynb
+++ b/docs/tutorials/regression.ipynb
@@ -28,23 +28,23 @@
    "source": [
     "## Reading Data\n",
     "\n",
-    "Load your data into a `Table`, the data is available under `docs/tutorials/data/pricing.csv`:"
+    "Download the house sales data from [here](https://github.com/Safe-DS/Datasets/blob/main/src/safeds_datasets/tabular/_house_sales/data/house_sales.csv) and load it into a `Table`:"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "from safeds.data.tabular.containers import Table\n",
     "\n",
     "pricing = Table.from_csv_file(\"data/house_sales.csv\")\n",
     "# For visualisation purposes, we only print out the first 15 rows.\n",
     "pricing.slice_rows(length=15)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -57,7 +57,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "pricing_columns = (\n",
     "    # Removes columns \"latitude\" and \"longitude\" from table\n",
@@ -69,16 +71,12 @@
     ")\n",
     "# For visualisation purposes, we only print out the first 5 rows.\n",
     "pricing_columns.slice_rows(length=5)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "See how to perform further data cleaning at: [Data Processing Tutorial](/tutorials/data_processing)"
-   ]
+   "source": "See how to perform further data cleaning in the dedicated [Data Processing Tutorial](../data_processing)."
   },
   {
    "cell_type": "markdown",
@@ -93,14 +91,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "train_table, testing_table = pricing_columns.split_rows(0.60)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -113,16 +111,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "extra_names = [\"id\"]\n",
     "\n",
     "train_tabular_dataset = train_table.to_tabular_dataset(\"price\", extra_names=extra_names)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -137,16 +135,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "from safeds.ml.classical.regression import DecisionTreeRegressor\n",
     "\n",
     "fitted_model = DecisionTreeRegressor().fit(train_tabular_dataset)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -161,16 +159,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "prediction = fitted_model.predict(testing_table)\n",
     "# For visualisation purposes we only print out the first 15 rows.\n",
     "prediction.to_table().slice_rows(length=15)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -185,14 +183,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "fitted_model.mean_absolute_error(testing_table)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -203,7 +201,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from safeds.data.tabular.containers import Table\n",
     "from safeds.ml.classical.regression import DecisionTreeRegressor\n",
@@ -225,9 +225,7 @@
     "prediction = fitted_model.predict(testing_table)\n",
     "\n",
     "fitted_model.mean_absolute_error(testing_table)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/src/safeds/data/tabular/transformation/__init__.py
+++ b/src/safeds/data/tabular/transformation/__init__.py
@@ -22,7 +22,7 @@ apipkg.initpkg(
     __name__,
     {
         "Discretizer": "._discretizer:Discretizer",
-        "FunctionalTableTransformer": "._functional_table_transformer",
+        "FunctionalTableTransformer": "._functional_table_transformer:FunctionalTableTransformer",
         "InvertibleTableTransformer": "._invertible_table_transformer:InvertibleTableTransformer",
         "LabelEncoder": "._label_encoder:LabelEncoder",
         "OneHotEncoder": "._one_hot_encoder:OneHotEncoder",

--- a/src/safeds/data/tabular/transformation/__init__.py
+++ b/src/safeds/data/tabular/transformation/__init__.py
@@ -6,6 +6,7 @@ import apipkg
 
 if TYPE_CHECKING:
     from ._discretizer import Discretizer
+    from ._functional_table_transformer import FunctionalTableTransformer
     from ._invertible_table_transformer import InvertibleTableTransformer
     from ._k_nearest_neighbors_imputer import KNearestNeighborsImputer
     from ._label_encoder import LabelEncoder
@@ -16,10 +17,12 @@ if TYPE_CHECKING:
     from ._standard_scaler import StandardScaler
     from ._table_transformer import TableTransformer
 
+
 apipkg.initpkg(
     __name__,
     {
         "Discretizer": "._discretizer:Discretizer",
+        "FunctionalTableTransformer": "._functional_table_transformer",
         "InvertibleTableTransformer": "._invertible_table_transformer:InvertibleTableTransformer",
         "LabelEncoder": "._label_encoder:LabelEncoder",
         "OneHotEncoder": "._one_hot_encoder:OneHotEncoder",
@@ -34,6 +37,7 @@ apipkg.initpkg(
 
 __all__ = [
     "Discretizer",
+    "FunctionalTableTransformer",
     "InvertibleTableTransformer",
     "LabelEncoder",
     "OneHotEncoder",

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -26,13 +26,12 @@ class FunctionalTableTransformer(TableTransformer):
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self,
-                 transformer: Callable[[Table], Table],
-                 ) -> None:
+    def __init__(
+        self,
+        transformer: Callable[[Table], Table],
+    ) -> None:
         super().__init__(None)
         self._transformer = transformer
-
-        
 
     def __hash__(self) -> int:
         return _structural_hash(

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -92,11 +92,7 @@ class FunctionalTableTransformer(TableTransformer):
             Raised when the wrapped callable encounters an error.
         
         """
-        try:
-            return self._transformer(table)
-        except Exception as e:
-            #TODO Evaluate if switch to non-generic exception is useful, as _func can be any callable
-            raise Exception("The underlying function encountered an error") from e  # noqa: TRY002
+        return self._transformer(table)
 
     def fit_and_transform(self, table: Table) -> tuple[FunctionalTableTransformer, Table]:
         """

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -86,11 +86,16 @@ class FunctionalTableTransformer(TableTransformer):
 
         Raises
         ------
-        #TODO Implement Errors from the table methods
+        Exception:
+            Raised when the called _func encounters an error.
+        #TODO Switch to non-generic exception
         
         """
-        transformed_table = self._func.__call__(table)
-        return transformed_table
+        try:
+            transformed_table = self._func.__call__(table)
+            return transformed_table
+        except Exception as e:
+            raise Exception("The underlying function encountered an error") from e
 
     def fit_and_transform(self, table: Table) -> tuple[Self, Table]:
         """

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -30,14 +30,14 @@ class FunctionalTableTransformer(TableTransformer):
                  transformer: Callable[[Table], Table],
                  ) -> None:
         super().__init__(None)
-        self._func = transformer
+        self._transformer = transformer
 
         
 
     def __hash__(self) -> int:
         return _structural_hash(
             super().__hash__(),
-            self._func,
+            self._transformer,
         )
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -93,7 +93,7 @@ class FunctionalTableTransformer(TableTransformer):
         
         """
         try:
-            return self._func(table)
+            return self._transformer(table)
         except Exception as e:
             #TODO Evaluate if switch to non-generic exception is useful, as _func can be any callable
             raise Exception("The underlying function encountered an error") from e  # noqa: TRY002

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -18,7 +18,7 @@ class FunctionalTableTransformer(TableTransformer):
 
     Parameters
     ----------
-    funct:
+    transformer:
         The Callable that receives a table and returns a table that is to be wrapped.
     """
 
@@ -27,10 +27,10 @@ class FunctionalTableTransformer(TableTransformer):
     # ------------------------------------------------------------------------------------------------------------------
 
     def __init__(self,
-                 funct: Callable[[Table], Table],
+                 transformer: Callable[[Table], Table],
                  ) -> None:
         super().__init__(None)
-        self._func = funct
+        self._func = transformer
 
         
 

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Self
+
+from safeds._utils import _structural_hash
+
+from ._table_transformer import TableTransformer
+
+if TYPE_CHECKING:
+    from safeds.data.tabular.containers import Table
+
+class FunctionalTableTransformer(TableTransformer):
+    """
+    Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns.
+
+    Parameters
+    ----------
+    column_names:
+        The list of columns used to fit the transformer. If `None`, all suitable columns are used.
+    """
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Dunder methods
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def __init__(self,
+                 func: callable[[Table], Table],
+                 ) -> None:
+        super().__init__(None)
+        self._func: callable[[Table], Table] = func
+
+        
+
+    def __hash__(self) -> int:
+        return _structural_hash(
+            super().__hash__(),
+            self._func,
+        )
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------------------------------------------------------
+
+    @property
+    def is_fitted(self) -> bool:
+        """FunctionalTableTransformer is always considered to be fitted."""
+        return True
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Learning and transformation
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def fit(self, table: Table) -> Self:
+        """
+        **Note:** For FunctionalTableTransformer this is a no-OP.
+
+        Parameters
+        ----------
+        table:
+            Required only to be consistent with other transformers.
+
+        Returns
+        -------
+        fitted_transformer:
+            self is always fitted.
+            
+        """
+        fitted_transformer = self
+        return fitted_transformer
+
+    def transform(self, table: Table) -> Table:
+        """
+        Apply the callable to a table.
+
+        **Note:** The given table is not modified.
+
+        Parameters
+        ----------
+        table:
+            The table on which on which the callable is executed.
+
+        Returns
+        -------
+        transformed_table:
+            The transformed table.
+
+        Raises
+        ------
+        #TODO Implement Errors from the table methods
+        
+        """
+        transformed_table = self._func.__call__(table)
+        return transformed_table
+
+    def fit_and_transform(self, table: Table) -> tuple[Self, Table]:
+        """
+        **Note:** For the FunctionalTableTransformer this is the same as transform().
+
+        Parameters
+        ----------
+        table:
+            The table on which the callable .
+
+        Returns
+        -------
+        fitted_transformer:
+            self is always fitted.
+        transformed_table:
+            The transformed table.
+        """
+        fitted_transformer = self
+        transformed_table = self.transform(table)
+        return fitted_transformer, transformed_table

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -14,12 +14,12 @@ from ._table_transformer import TableTransformer
 
 class FunctionalTableTransformer(TableTransformer):
     """
-    Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns.
+    Wraps a Callable[[Table], Table] so that it can be used in a SequentialTableTransformer.
 
     Parameters
     ----------
     transformer:
-        The Callable that receives a table and returns a table that is to be wrapped.
+        The Callable that receives a table and returns a table.
     """
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -14,12 +14,12 @@ from ._table_transformer import TableTransformer
 
 class FunctionalTableTransformer(TableTransformer):
     """
-    Wraps a Callable[[Table], Table] so that it can be used in a SequentialTableTransformer.
+    Wraps a callable so that it conforms to the TableTransformer interface.
 
     Parameters
     ----------
     transformer:
-        The Callable that receives a table and returns a table.
+        A callable that receives a table and returns a table.
     """
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -65,7 +65,6 @@ class FunctionalTableTransformer(TableTransformer):
         -------
         fitted_transformer:
             Returns self, because this transformer is always fitted.
-
         """
         return self
 
@@ -89,7 +88,6 @@ class FunctionalTableTransformer(TableTransformer):
         ------
         Exception:
             Raised when the wrapped callable encounters an error.
-
         """
         return self._transformer(table)
 

--- a/src/safeds/data/tabular/transformation/_functional_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_functional_table_transformer.py
@@ -5,9 +5,10 @@ from typing import TYPE_CHECKING, Self
 from safeds._utils import _structural_hash
 
 from ._table_transformer import TableTransformer
+from safeds.data.tabular.containers import Table
 
-if TYPE_CHECKING:
-    from safeds.data.tabular.containers import Table
+#if TYPE_CHECKING:
+#    from safeds.data.tabular.containers import Table
 
 class FunctionalTableTransformer(TableTransformer):
     """
@@ -24,10 +25,10 @@ class FunctionalTableTransformer(TableTransformer):
     # ------------------------------------------------------------------------------------------------------------------
 
     def __init__(self,
-                 func: callable[[Table], Table],
+                 funct,
                  ) -> None:
         super().__init__(None)
-        self._func: callable[[Table], Table] = func
+        self._func = funct
 
         
 
@@ -50,7 +51,7 @@ class FunctionalTableTransformer(TableTransformer):
     # Learning and transformation
     # ------------------------------------------------------------------------------------------------------------------
 
-    def fit(self, table: Table) -> Self:
+    def fit(self, table: Table) -> FunctionalTableTransformer:
         """
         **Note:** For FunctionalTableTransformer this is a no-OP.
 
@@ -92,12 +93,12 @@ class FunctionalTableTransformer(TableTransformer):
         
         """
         try:
-            transformed_table = self._func.__call__(table)
+            transformed_table = self._func(table)
             return transformed_table
         except Exception as e:
             raise Exception("The underlying function encountered an error") from e
 
-    def fit_and_transform(self, table: Table) -> tuple[Self, Table]:
+    def fit_and_transform(self, table: Table) -> tuple[FunctionalTableTransformer, Table]:
         """
         **Note:** For the FunctionalTableTransformer this is the same as transform().
 

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -1,6 +1,6 @@
 import pytest
 from safeds.data.tabular.containers import Table
-from safeds.data.tabular.transformation._functional_table_transformer import FunctionalTableTransformer
+from safeds.data.tabular.transformation import FunctionalTableTransformer
 from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, TransformerNotFittedError
 
 
@@ -45,7 +45,7 @@ class TestTransform:
             },
         )
         transformer = FunctionalTableTransformer(self.valid_callable())
-        with pytest.raises(Exception), match=r"The underlying function encountered an error"):
+        with pytest.raises(Exception, match=r"The underlying function encountered an error"):
             transformer.transform(table)
 
     def should_not_modify_original_table(self):

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -3,9 +3,6 @@ from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import FunctionalTableTransformer
 
 
-def invalid_callable(i: int) -> float:
-    return float(i)
-    
 def valid_callable(table: Table) -> Table:
     return table.remove_columns(["col1"])
 
@@ -38,17 +35,6 @@ class TestTransform:
             },
         )
         transformer = FunctionalTableTransformer(valid_callable)
-        with pytest.raises(Exception, match=r"The underlying function encountered an error"):
-            transformer.transform(table)
-
-    def test_should_raise_generic_error_when_callable_wrong_type(self) -> None:
-        table = Table(
-            {
-                "col2": [1, 2, 3],
-            
-            },
-        )
-        transformer = FunctionalTableTransformer(invalid_callable)
         with pytest.raises(Exception, match=r"The underlying function encountered an error"):
             transformer.transform(table)
 

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -6,7 +6,7 @@ from safeds.data.tabular.transformation import FunctionalTableTransformer
 def invalid_callable(i: int) -> float:
     return float(i)
     
-def valid_callable(table) -> Table:
+def valid_callable(table: Table) -> Table:
     return table.remove_columns(["col1"])
 
 class TestInit:

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -1,6 +1,7 @@
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import FunctionalTableTransformer
+from safeds.exceptions import ColumnNotFoundError
 
 
 def valid_callable(table: Table) -> Table:
@@ -27,7 +28,7 @@ class TestIsFitted:
         assert transformer.is_fitted
 
 class TestTransform:
-    def test_should_raise_generic_error_when_error_in_method(self) -> None:
+    def test_should_raise_specific_error_when_error_in_method(self) -> None:
         table = Table(
             {
                 "col2": [1, 2, 3],
@@ -35,7 +36,7 @@ class TestTransform:
             },
         )
         transformer = FunctionalTableTransformer(valid_callable)
-        with pytest.raises(Exception, match=r"The underlying function encountered an error"):
+        with pytest.raises(ColumnNotFoundError):
             transformer.transform(table)
 
     def test_should_not_modify_original_table(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -8,12 +8,11 @@ class TestInit:
     def should_raise_type_error(self):
         assert None is not None
 
-
-
 class TestFit:
     def valid_callable(table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
+    
     def should_return_self(self) -> FunctionalTableTransformer:
         table = Table(
             {
@@ -24,14 +23,48 @@ class TestFit:
         transformer = FunctionalTableTransformer(self.valid_callable())
         assert transformer.fit(table) is transformer
 
+class TestIsFitted:
+    def valid_callable(table: Table) -> Table:
+        new_table = table.remove_columns(["col1"])
+        return new_table
+    
+    def should_always_be_fitted(self) -> bool:
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        assert transformer.is_fitted
+
 class TestTransform:
     def valid_callable(table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
-    def sshould_raise_generic_error(self):
-        #TODO: implement try catch for main method
-        #TODO: test with a callable like remove columns where we can check error returning if we return non generic error
-        assert None is not None
+    
+    def should_raise_generic_error(self):
+        table = Table(
+            {
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        with pytest.raises(Exception), match=r"The underlying function encountered an error"):
+            transformer.transform(table)
+
+    def should_not_modify_original_table(self):
+        table = Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer.transform(table)
+        assert table == Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
 
 class TestFitAndTransform:
     def valid_callable(table: Table) -> Table:
@@ -67,7 +100,7 @@ class TestFitAndTransform:
             },
         )
 
-        
+
 
 
 

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -1,36 +1,19 @@
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import FunctionalTableTransformer
-from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, TransformerNotFittedError
 
 
-#def invalid_callable(i: int) -> float:
-#    return float(i)
+def invalid_callable(i: int) -> float:
+    return float(i)
     
-#def valid_callable(table) -> Table:
-#    new_table = table.remove_columns(["col1"])
-#    return new_table
+def valid_callable(table) -> Table:
+    return table.remove_columns(["col1"])
 
 class TestInit:
-    def invalid_callable(self, i: int) -> float:
-        return float(i)
-    
-    def valid_callable(self, table) -> Table:
-        new_table = table.remove_columns(self, ["col1"])
-        return new_table
-
-    #def test_should_raise_type_error(self) -> None:
-    #    with pytest.raises(TypeError):
-    #        transformer = FunctionalTableTransformer(invalid_callable)
-    
     def test_should_not_raise_type_error(self) -> None:
-            transformer = FunctionalTableTransformer(self.valid_callable)
+            FunctionalTableTransformer(valid_callable)
 
 class TestFit:
-    def valid_callable(self, table: Table) -> Table:
-        new_table = table.remove_columns(["col1"])
-        return new_table
-    
     def test_should_return_self(self) -> None:
         table = Table(
             {
@@ -38,31 +21,34 @@ class TestFit:
                 "col2": [1, 2, 3],
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         assert transformer.fit(table) is transformer
 
 class TestIsFitted:
-    def valid_callable(self, table: Table) -> Table:
-        new_table = table.remove_columns(["col1"])
-        return new_table
-    
     def test_should_always_be_fitted(self) -> None:
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         assert transformer.is_fitted
 
 class TestTransform:
-    def valid_callable(self, table: Table) -> Table:
-        new_table = table.remove_columns(["col1"])
-        return new_table
-    
-    def test_should_raise_generic_error(self) -> None:
+    def test_should_raise_generic_error_when_error_in_method(self) -> None:
         table = Table(
             {
                 "col2": [1, 2, 3],
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
+        with pytest.raises(Exception, match=r"The underlying function encountered an error"):
+            transformer.transform(table)
+
+    def test_should_raise_generic_error_when_callable_wrong_type(self) -> None:
+        table = Table(
+            {
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(invalid_callable)
         with pytest.raises(Exception, match=r"The underlying function encountered an error"):
             transformer.transform(table)
 
@@ -74,7 +60,7 @@ class TestTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         transformer.transform(table)
         assert table == Table(
             {
@@ -92,7 +78,7 @@ class TestTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         transformed_table = transformer.transform(table)
         assert transformed_table == Table(
             {
@@ -102,10 +88,6 @@ class TestTransform:
         )
 
 class TestFitAndTransform:
-    def valid_callable(self, table: Table) -> Table:
-        new_table = table.remove_columns(["col1"])
-        return new_table
-
     def test_should_return_self(self) -> None:
         table = Table(
             {
@@ -114,7 +96,7 @@ class TestFitAndTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         assert transformer.fit_and_transform(table)[0] is transformer
 
     def test_should_not_modify_original_table(self) -> None:
@@ -125,7 +107,7 @@ class TestFitAndTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformer = FunctionalTableTransformer(valid_callable)
         transformer.fit_and_transform(table)
         assert table == Table(
             {

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -5,15 +5,19 @@ from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, TransformerN
 
 
 class TestInit:
-    def should_raise_type_error(self):
-        assert None is not None
+    def invalid_callable(i: int) -> float:
+        return float(i)
+
+    def test_should_raise_type_error(self):
+        with pytest.raises(TypeError):
+            _transformer = FunctionalTableTransformer(self.invalid_callable())
 
 class TestFit:
     def valid_callable(table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def should_return_self(self) -> FunctionalTableTransformer:
+    def test_should_return_self(self) -> FunctionalTableTransformer:
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -28,7 +32,7 @@ class TestIsFitted:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def should_always_be_fitted(self) -> bool:
+    def test_should_always_be_fitted(self) -> bool:
         transformer = FunctionalTableTransformer(self.valid_callable())
         assert transformer.is_fitted
 
@@ -37,7 +41,7 @@ class TestTransform:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def should_raise_generic_error(self):
+    def test_should_raise_generic_error(self):
         table = Table(
             {
                 "col2": [1, 2, 3],
@@ -48,7 +52,7 @@ class TestTransform:
         with pytest.raises(Exception, match=r"The underlying function encountered an error"):
             transformer.transform(table)
 
-    def should_not_modify_original_table(self):
+    def test_should_not_modify_original_table(self):
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -71,7 +75,7 @@ class TestFitAndTransform:
         new_table = table.remove_columns(["col1"])
         return new_table
 
-    def should_return_self(self):
+    def test_should_return_self(self):
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -82,7 +86,7 @@ class TestFitAndTransform:
         transformer = FunctionalTableTransformer(self.valid_callable())
         assert transformer.fit_and_transform(table)[0] is transformer
 
-    def should_not_modify_original_table(self):
+    def test_should_not_modify_original_table(self):
         table = Table(
             {
                 "col1": [1, 2, 3],

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -4,55 +4,69 @@ from safeds.data.tabular.transformation import FunctionalTableTransformer
 from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, TransformerNotFittedError
 
 
-class TestInit:
-    def invalid_callable(i: int) -> float:
-        return float(i)
+#def invalid_callable(i: int) -> float:
+#    return float(i)
+    
+#def valid_callable(table) -> Table:
+#    new_table = table.remove_columns(["col1"])
+#    return new_table
 
-    def test_should_raise_type_error(self):
-        with pytest.raises(TypeError):
-            _transformer = FunctionalTableTransformer(self.invalid_callable())
+class TestInit:
+    def invalid_callable(self, i: int) -> float:
+        return float(i)
+    
+    def valid_callable(self, table) -> Table:
+        new_table = table.remove_columns(self, ["col1"])
+        return new_table
+
+    #def test_should_raise_type_error(self) -> None:
+    #    with pytest.raises(TypeError):
+    #        transformer = FunctionalTableTransformer(invalid_callable)
+    
+    def test_should_not_raise_type_error(self) -> None:
+            transformer = FunctionalTableTransformer(self.valid_callable)
 
 class TestFit:
-    def valid_callable(table: Table) -> Table:
+    def valid_callable(self, table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def test_should_return_self(self) -> FunctionalTableTransformer:
+    def test_should_return_self(self) -> None:
         table = Table(
             {
                 "col1": [1, 2, 3],
                 "col2": [1, 2, 3],
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer = FunctionalTableTransformer(self.valid_callable)
         assert transformer.fit(table) is transformer
 
 class TestIsFitted:
-    def valid_callable(table: Table) -> Table:
+    def valid_callable(self, table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def test_should_always_be_fitted(self) -> bool:
-        transformer = FunctionalTableTransformer(self.valid_callable())
+    def test_should_always_be_fitted(self) -> None:
+        transformer = FunctionalTableTransformer(self.valid_callable)
         assert transformer.is_fitted
 
 class TestTransform:
-    def valid_callable(table: Table) -> Table:
+    def valid_callable(self, table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
     
-    def test_should_raise_generic_error(self):
+    def test_should_raise_generic_error(self) -> None:
         table = Table(
             {
                 "col2": [1, 2, 3],
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer = FunctionalTableTransformer(self.valid_callable)
         with pytest.raises(Exception, match=r"The underlying function encountered an error"):
             transformer.transform(table)
 
-    def test_should_not_modify_original_table(self):
+    def test_should_not_modify_original_table(self) -> None:
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -60,7 +74,7 @@ class TestTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer = FunctionalTableTransformer(self.valid_callable)
         transformer.transform(table)
         assert table == Table(
             {
@@ -70,12 +84,29 @@ class TestTransform:
             },
         )
 
+    def test_should_return_modified_table(self) -> None:
+        table = Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable)
+        transformed_table = transformer.transform(table)
+        assert transformed_table == Table(
+            {
+                "col2": [1, 2, 3],
+            
+            },
+        )
+
 class TestFitAndTransform:
-    def valid_callable(table: Table) -> Table:
+    def valid_callable(self, table: Table) -> Table:
         new_table = table.remove_columns(["col1"])
         return new_table
 
-    def test_should_return_self(self):
+    def test_should_return_self(self) -> None:
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -83,10 +114,10 @@ class TestFitAndTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer = FunctionalTableTransformer(self.valid_callable)
         assert transformer.fit_and_transform(table)[0] is transformer
 
-    def test_should_not_modify_original_table(self):
+    def test_should_not_modify_original_table(self) -> None:
         table = Table(
             {
                 "col1": [1, 2, 3],
@@ -94,7 +125,7 @@ class TestFitAndTransform:
             
             },
         )
-        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer = FunctionalTableTransformer(self.valid_callable)
         transformer.fit_and_transform(table)
         assert table == Table(
             {
@@ -103,13 +134,3 @@ class TestFitAndTransform:
             
             },
         )
-
-
-
-
-
-
-
-        
-
-        

--- a/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_functional_table_transformer.py
@@ -1,0 +1,78 @@
+import pytest
+from safeds.data.tabular.containers import Table
+from safeds.data.tabular.transformation._functional_table_transformer import FunctionalTableTransformer
+from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, TransformerNotFittedError
+
+
+class TestInit:
+    def should_raise_type_error(self):
+        assert None is not None
+
+
+
+class TestFit:
+    def valid_callable(table: Table) -> Table:
+        new_table = table.remove_columns(["col1"])
+        return new_table
+    def should_return_self(self) -> FunctionalTableTransformer:
+        table = Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        assert transformer.fit(table) is transformer
+
+class TestTransform:
+    def valid_callable(table: Table) -> Table:
+        new_table = table.remove_columns(["col1"])
+        return new_table
+    def sshould_raise_generic_error(self):
+        #TODO: implement try catch for main method
+        #TODO: test with a callable like remove columns where we can check error returning if we return non generic error
+        assert None is not None
+
+class TestFitAndTransform:
+    def valid_callable(table: Table) -> Table:
+        new_table = table.remove_columns(["col1"])
+        return new_table
+
+    def should_return_self(self):
+        table = Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        assert transformer.fit_and_transform(table)[0] is transformer
+
+    def should_not_modify_original_table(self):
+        table = Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
+        transformer = FunctionalTableTransformer(self.valid_callable())
+        transformer.fit_and_transform(table)
+        assert table == Table(
+            {
+                "col1": [1, 2, 3],
+                "col2": [1, 2, 3],
+            
+            },
+        )
+
+        
+
+
+
+
+
+        
+
+        

--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -51,8 +51,10 @@ def transformers_non_numeric() -> list[TableTransformer]:
         LabelEncoder(column_names="col1"),
     ]
 
+
 def valid_callable_for_functional_table_transformer(table: Table) -> Table:
     return table.remove_columns(["col1"])
+
 
 def transformers() -> list[TableTransformer]:
     """

--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -4,6 +4,7 @@ import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import (
     Discretizer,
+    FunctionalTableTransformer,
     KNearestNeighborsImputer,
     LabelEncoder,
     OneHotEncoder,
@@ -50,6 +51,8 @@ def transformers_non_numeric() -> list[TableTransformer]:
         LabelEncoder(column_names="col1"),
     ]
 
+def valid_callable_for_functional_table_transformer(table: Table) -> Table:
+    return table.remove_columns(["col1"])
 
 def transformers() -> list[TableTransformer]:
     """
@@ -69,6 +72,7 @@ def transformers() -> list[TableTransformer]:
         + [
             SimpleImputer(strategy=SimpleImputer.Strategy.mode()),
             KNearestNeighborsImputer(neighbor_count=3, value_to_replace=None),
+            FunctionalTableTransformer(valid_callable_for_functional_table_transformer),
         ]
     )
 


### PR DESCRIPTION
Closes #858 

### Summary of Changes

This implements a Transformer that wraps a Callable[[Table], Table] so operations on Tables can be inserted into the operation order of a SequentialTableTransformer.
Note that this transformer inherently cannot be invertible.
Since there is no type checking at runtime, callables with wrong argument or return types will only throw an exception upon calling transform but not during init.
