### PR TITLE
test: Added RobustScaler to test_table_transformer.py

### DIFF
--- a/tests/safeds/data/tabular/transformation/test_table_transformer.py
+++ b/tests/safeds/data/tabular/transformation/test_table_transformer.py
@@ -8,6 +8,7 @@ from safeds.data.tabular.transformation import (
     LabelEncoder,
     OneHotEncoder,
     RangeScaler,
+    RobustScaler,
     SimpleImputer,
     StandardScaler,
     TableTransformer,
@@ -30,6 +31,7 @@ def transformers_numeric() -> list[TableTransformer]:
         StandardScaler(column_names="col1"),
         RangeScaler(column_names="col1"),
         Discretizer(column_names="col1"),
+        RobustScaler(column_names="col1"),
     ]
 
 


### PR DESCRIPTION
Closes #902

### Summary of Changes

Test coverage for RobustScaler.\_\_ hash\_\_() by adding RobustScaler to the list of Numeric Table Transformers in test_table_transformer.py