### PR TITLE
fix: unwrap operators of cell operations

### DIFF
--- a/src/safeds/data/tabular/containers/_cell.py
+++ b/src/safeds/data/tabular/containers/_cell.py
@@ -599,6 +599,36 @@ class Cell(ABC, Generic[T_co]):
         """
         return self.__eq__(other)
 
+    def neq(self, other: Any) -> Cell[bool]:
+        """
+        Check if not equal to a value. This is equivalent to the `!=` operator.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Column
+        >>> column = Column("example", [1, 2])
+        >>> column.transform(lambda cell: cell.neq(2))
+        +---------+
+        | example |
+        | ---     |
+        | bool    |
+        +=========+
+        | true    |
+        | false   |
+        +---------+
+
+        >>> column.transform(lambda cell: cell != 2)
+        +---------+
+        | example |
+        | ---     |
+        | bool    |
+        +=========+
+        | true    |
+        | false   |
+        +---------+
+        """
+        return self.__ne__(other)
+
     def ge(self, other: Any) -> Cell[bool]:
         """
         Check if greater than or equal to a value. This is equivalent to the `>=` operator.

--- a/src/safeds/data/tabular/containers/_lazy_cell.py
+++ b/src/safeds/data/tabular/containers/_lazy_cell.py
@@ -39,21 +39,27 @@ class _LazyCell(Cell[T]):
         return _wrap(self._expression.cast(pl.Boolean).__invert__())
 
     def __and__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__and__(other))
 
     def __rand__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__rand__(other))
 
     def __or__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__or__(other))
 
     def __ror__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__ror__(other))
 
     def __xor__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__xor__(other))
 
     def __rxor__(self, other: bool | Cell[bool]) -> Cell[bool]:
+        other = _unwrap(other)
         return _wrap(self._expression.__rxor__(other))
 
     # Comparison ---------------------------------------------------------------

--- a/tests/safeds/data/tabular/containers/_cell/test_add.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_add.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_add.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_add.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeAddition:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell + value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell + _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 + cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) + cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.add(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.add(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_and.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_and.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_and.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_and.py
@@ -2,6 +2,9 @@ from typing import Any
 
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -32,8 +35,17 @@ class TestShouldComputeConjunction:
     def test_dunder_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell & value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell & _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 & cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) & cell, expected)
+
     def test_named_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.and_(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.and_(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_div.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_div.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_div.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_div.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeDivision:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell / value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell / _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 / cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) / cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.div(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.div(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_eq.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_eq.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeEquality:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell == value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell == _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 == cell, expected)  # type: ignore[arg-type,return-value]
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) == cell, expected)  # type: ignore[arg-type,return-value]
+
     def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.eq(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.eq(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_floordiv.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_floordiv.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_floordiv.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_floordiv.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,5 +25,11 @@ class TestShouldComputeDivision:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell // value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell // _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 // cell, expected)
+
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) // cell, expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_ge.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_ge.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_ge.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_ge.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeGreaterThanOrEqual:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell >= value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell >= _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 >= cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) >= cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.ge(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.ge(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_gt.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_gt.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_gt.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_gt.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeGreaterThan:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell > value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell > _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 > cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) > cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.gt(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.gt(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_le.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_le.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_le.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_le.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeLessThanOrEqual:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell <= value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell <= _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 <= cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) <= cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.le(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.le(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_lt.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_lt.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_lt.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_lt.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeLessThan:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell < value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell < _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 < cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) < cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.lt(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.lt(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_mod.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_mod.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_mod.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_mod.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeModulus:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell % value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell % _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 % cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) % cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.mod(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.mod(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_mul.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_mul.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_mul.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_mul.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeMultiplication:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell * value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell * _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 * cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) * cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.mul(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.mul(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_ne.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_ne.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_ne.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_ne.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,5 +25,17 @@ class TestShouldComputeNegatedEquality:
     def test_dunder_method(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell != value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell != _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: value2 != cell, expected)  # type: ignore[arg-type,return-value]
+
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: _LazyCell(pl.lit(value2)) != cell, expected)  # type: ignore[arg-type,return-value]
+
+    def test_named_method(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.neq(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.neq(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_or.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_or.py
@@ -2,6 +2,9 @@ from typing import Any
 
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -32,8 +35,17 @@ class TestShouldComputeDisjunction:
     def test_dunder_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell | value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell | _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 | cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) | cell, expected)
+
     def test_named_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.or_(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.or_(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_or.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_or.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_pow.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_pow.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputePower:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell**value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell**_LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1**cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1))**cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.pow(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.pow(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_pow.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_pow.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 
@@ -26,13 +25,13 @@ class TestShouldComputePower:
         assert_cell_operation_works(value1, lambda cell: cell**value2, expected)
 
     def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell**_LazyCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(value1, lambda cell: cell ** _LazyCell(pl.lit(value2)), expected)
 
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1**cell, expected)
 
     def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
-        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1))**cell, expected)
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) ** cell, expected)
 
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.pow(value2), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_sub.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_sub.py
@@ -1,8 +1,7 @@
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_cell/test_sub.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_sub.py
@@ -1,5 +1,8 @@
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -22,8 +25,17 @@ class TestShouldComputeSubtraction:
     def test_dunder_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell - value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell - _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 - cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) - cell, expected)
+
     def test_named_method(self, value1: float, value2: float, expected: float) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.sub(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: float, value2: float, expected: float) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.sub(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_xor.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_xor.py
@@ -2,6 +2,9 @@ from typing import Any
 
 import pytest
 
+import polars as pl
+
+from safeds.data.tabular.containers._lazy_cell import _LazyCell
 from tests.helpers import assert_cell_operation_works
 
 
@@ -32,8 +35,17 @@ class TestShouldComputeExclusiveOr:
     def test_dunder_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell ^ value2, expected)
 
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell ^ _LazyCell(pl.lit(value2)), expected)
+
     def test_dunder_method_inverted_order(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value2, lambda cell: value1 ^ cell, expected)
 
+    def test_dunder_method_inverted_order_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value2, lambda cell: _LazyCell(pl.lit(value1)) ^ cell, expected)
+
     def test_named_method(self, value1: Any, value2: bool, expected: bool) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.xor(value2), expected)
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool, expected: bool) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell.xor(_LazyCell(pl.lit(value2))), expected)

--- a/tests/safeds/data/tabular/containers/_cell/test_xor.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_xor.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-import pytest
-
 import polars as pl
-
+import pytest
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
+
 from tests.helpers import assert_cell_operation_works
 
 


### PR DESCRIPTION
### Summary of Changes

Always unwrap the right operators of cell operations. This was missing in some cases, leading to runtime errors akin to 

```cannot create expression literal for value of type _LazyCell: <Expr ['[(col("Shortness of breath on …'] at 0x18E78C3E010>```
