### PR TITLE
feat: rename `Row.get_value` to `Row.get_cell`

### DIFF
--- a/benchmarks/table/row_operations.py
+++ b/benchmarks/table/row_operations.py
@@ -1,9 +1,9 @@
 from timeit import timeit
 
 import polars as pl
-from safeds.data.tabular.containers import Table
 
 from benchmarks.table.utils import create_synthetic_table
+from safeds.data.tabular.containers import Table
 
 REPETITIONS = 10
 

--- a/benchmarks/table/row_operations.py
+++ b/benchmarks/table/row_operations.py
@@ -21,7 +21,7 @@ def _run_remove_rows_with_outliers() -> None:
 
 
 def _run_remove_rows() -> None:
-    table.remove_rows(lambda row: row.get_value("column_0") % 2 == 0)._lazy_frame.collect()
+    table.remove_rows(lambda row: row["column_0"] % 2 == 0)._lazy_frame.collect()
 
 
 def _run_remove_rows_by_column() -> None:
@@ -37,7 +37,7 @@ def _run_slice_rows() -> None:
 
 
 def _run_sort_rows() -> None:
-    table.sort_rows(lambda row: row.get_value("column_0"))._lazy_frame.collect()
+    table.sort_rows(lambda row: row["column_0"])._lazy_frame.collect()
 
 
 def _run_sort_rows_by_column() -> None:

--- a/docs/development/guidelines/documentation.md
+++ b/docs/development/guidelines/documentation.md
@@ -111,7 +111,7 @@ Examples
 --------
 >>> from safeds.data.tabular.containers import Row
 >>> row = Row({"a": 1, "b": 2})
->>> row.get_value("a")
+>>> row.get_cell("a")
 1
 """
 ```

--- a/docs/tutorials/data_processing.ipynb
+++ b/docs/tutorials/data_processing.ipynb
@@ -434,7 +434,7 @@
    ],
    "source": [
     "titanic.remove_rows(\n",
-    "    lambda row: row.get_value(\"age\") < 1\n",
+    "    lambda row: row[\"age\"] < 1\n",
     ")"
    ]
   },

--- a/src/safeds/data/tabular/containers/_lazy_vectorized_row.py
+++ b/src/safeds/data/tabular/containers/_lazy_vectorized_row.py
@@ -64,7 +64,7 @@ class _LazyVectorizedRow(Row):
     # Column operations
     # ------------------------------------------------------------------------------------------------------------------
 
-    def get_value(self, name: str) -> _LazyCell:
+    def get_cell(self, name: str) -> _LazyCell:
         import polars as pl
 
         _check_columns_exist(self._table, name)

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -28,7 +28,7 @@ class Row(ABC, Mapping[str, Any]):
     def __eq__(self, other: object) -> bool: ...
 
     def __getitem__(self, name: str) -> Cell:
-        return self.get_value(name)
+        return self.get_cell(name)
 
     @abstractmethod
     def __hash__(self) -> int: ...
@@ -66,9 +66,9 @@ class Row(ABC, Mapping[str, Any]):
     # ------------------------------------------------------------------------------------------------------------------
 
     @abstractmethod
-    def get_value(self, name: str) -> Cell:
+    def get_cell(self, name: str) -> Cell:
         """
-        Get the value of the specified column. This is equivalent to using the `[]` operator (indexed access).
+        Get the cell in the specified column. This is equivalent to using the `[]` operator (indexed access).
 
         Parameters
         ----------
@@ -77,8 +77,8 @@ class Row(ABC, Mapping[str, Any]):
 
         Returns
         -------
-        value:
-            The value of the column.
+        cell:
+            The cell in the specified column.
 
         Raises
         ------
@@ -89,7 +89,7 @@ class Row(ABC, Mapping[str, Any]):
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table({"col1": [1, 2], "col2": [3, 4]})
-        >>> table.remove_rows(lambda row: row.get_value("col1") == 1)
+        >>> table.remove_rows(lambda row: row.get_cell("col1") == 1)
         +------+------+
         | col1 | col2 |
         |  --- |  --- |

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -527,7 +527,7 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
-        >>> table.add_computed_column("c", lambda row: row.get_value("a") + row.get_value("b"))
+        >>> table.add_computed_column("c", lambda row: row["a"] + row["b"])
         +-----+-----+-----+
         |   a |   b |   c |
         | --- | --- | --- |
@@ -1135,7 +1135,7 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
-        >>> table.remove_rows(lambda row: row.get_value("a") == 2)
+        >>> table.remove_rows(lambda row: row["a"] == 2)
         +-----+-----+
         |   a |   b |
         | --- | --- |
@@ -1428,7 +1428,7 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table({"a": [2, 1, 3], "b": [1, 1, 2]})
-        >>> table.sort_rows(lambda row: row.get_value("a") - row.get_value("b"))
+        >>> table.sort_rows(lambda row: row["a"] - row["b"])
         +-----+-----+
         |   a |   b |
         | --- | --- |

--- a/tests/safeds/data/tabular/containers/_row/test_get_cell.py
+++ b/tests/safeds/data/tabular/containers/_row/test_get_cell.py
@@ -1,10 +1,10 @@
 import re
 
 import pytest
-from safeds.data.tabular.containers import Row, Table
+
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedRow
 from safeds.exceptions import ColumnNotFoundError
-
 from tests.helpers import assert_row_operation_works
 
 

--- a/tests/safeds/data/tabular/containers/_row/test_get_cell.py
+++ b/tests/safeds/data/tabular/containers/_row/test_get_cell.py
@@ -22,7 +22,7 @@ from tests.helpers import assert_row_operation_works
 def test_should_get_correct_item(table_data: dict, column_name: str, target: int, expected: dict) -> None:
     assert_row_operation_works(
         table_data,
-        lambda table: table.remove_rows(lambda row: row.get_value(column_name).eq(target)),
+        lambda table: table.remove_rows(lambda row: row.get_cell(column_name).eq(target)),
         expected,
     )
 
@@ -43,4 +43,4 @@ def test_should_get_correct_item(table_data: dict, column_name: str, target: int
 def test_should_raise_column_not_found_error(table: Table, column_name: str) -> None:
     row: Row[any] = _LazyVectorizedRow(table=table)
     with pytest.raises(ColumnNotFoundError, match=re.escape(f"Could not find column(s):\n    - '{column_name}'")):
-        row.get_value(column_name)
+        row.get_cell(column_name)

--- a/tests/safeds/data/tabular/containers/_row/test_get_cell.py
+++ b/tests/safeds/data/tabular/containers/_row/test_get_cell.py
@@ -41,6 +41,6 @@ def test_should_get_correct_item(table_data: dict, column_name: str, target: int
     ],
 )
 def test_should_raise_column_not_found_error(table: Table, column_name: str) -> None:
-    row: Row[any] = _LazyVectorizedRow(table=table)
+    row = _LazyVectorizedRow(table=table)
     with pytest.raises(ColumnNotFoundError, match=re.escape(f"Could not find column(s):\n    - '{column_name}'")):
         row.get_cell(column_name)

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
@@ -26,6 +26,6 @@ from safeds.data.tabular.containers import Table
     ],
 )
 def test_should_remove_rows(table1: Table, filter_column: str, filter_value: Any, table2: Table) -> None:
-    table1 = table1.remove_rows(lambda row: row.get_value(filter_column) == filter_value)
+    table1 = table1.remove_rows(lambda row: row[filter_column] == filter_value)
     assert table1.schema == table2.schema
     assert table2 == table1


### PR DESCRIPTION
### Summary of Changes

Rename `Row.get_value` to `Row.get_cell` to avoid confusion with `Column.get_value`. The row method returns a cell, while the column method returns an actual Python constant. The new name emphasizes this difference.
