### PR TITLE
feat: rename `count_row_if` to `count_rows_if`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1007,7 +1007,7 @@ class Table:
     # ------------------------------------------------------------------------------------------------------------------
 
     @overload
-    def count_row_if(
+    def count_rows_if(
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
@@ -1015,14 +1015,14 @@ class Table:
     ) -> int: ...
 
     @overload
-    def count_row_if(
+    def count_rows_if(
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
         ignore_unknown: bool,
     ) -> int | None: ...
 
-    def count_row_if(
+    def count_rows_if(
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
@@ -1059,10 +1059,10 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table({"col1": [1, 2, 3], "col2": [1, 3, 3]})
-        >>> table.count_row_if(lambda row: row["col1"] == row["col2"])
+        >>> table.count_rows_if(lambda row: row["col1"] == row["col2"])
         2
 
-        >>> table.count_row_if(lambda row: row["col1"] > row["col2"])
+        >>> table.count_rows_if(lambda row: row["col1"] > row["col2"])
         0
         """
         expression = predicate(_LazyVectorizedRow(self))._polars_expression

--- a/tests/safeds/data/tabular/containers/_table/test_count_rows_if.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_rows_if.py
@@ -30,7 +30,7 @@ def test_should_handle_boolean_logic(
     expected: int,
 ) -> None:
     table = Table({"a": values})
-    assert table.count_row_if(lambda row: row["a"] < 2) == expected
+    assert table.count_rows_if(lambda row: row["a"] < 2) == expected
 
 
 @pytest.mark.parametrize(
@@ -61,4 +61,4 @@ def test_should_handle_kleene_logic(
     expected: int | None,
 ) -> None:
     table = Table({"a": values})
-    assert table.count_row_if(lambda row: row["a"] < 2, ignore_unknown=False) == expected
+    assert table.count_rows_if(lambda row: row["a"] < 2, ignore_unknown=False) == expected

--- a/tests/safeds/data/tabular/containers/_table/test_count_rows_if.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_rows_if.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 


### PR DESCRIPTION
### Summary of Changes

Rename `Table.count_row_if` to `Table.count_rows_if` (plural). 

For all other methods of `Table`, the plural form was used, but if users typed "rows", this method was not suggested by auto-completion. The `_if` suffix is still included, to distinguish the method from the attribute `row_count`.
