### PR TITLE
feat: remove `Image.__array__`

### DIFF
--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -23,7 +23,6 @@ from safeds.data.image.typing import ImageSize
 from safeds.exceptions import IllegalFormatError
 
 if TYPE_CHECKING:
-    from numpy import dtype, ndarray
     from torch import Tensor
 
 
@@ -173,25 +172,6 @@ class Image:
             Size of this object in bytes.
         """
         return sys.getsizeof(self._image_tensor) + self._image_tensor.element_size() * self._image_tensor.nelement()
-
-    def __array__(self, numpy_dtype: str | dtype | None = None) -> ndarray:
-        """
-        Return the image as a numpy array.
-
-        Returns
-        -------
-        numpy_array:
-            The image as numpy array.
-        """
-        from numpy import uint8
-
-        return (
-            self._image_tensor.permute(1, 2, 0)
-            .detach()
-            .cpu()
-            .numpy()
-            .astype(uint8 if numpy_dtype is None else numpy_dtype)
-        )
 
     def _repr_jpeg_(self) -> bytes | None:
         """


### PR DESCRIPTION
### Summary of Changes

Remove the `Image.__array__` dunder method, which is used if an `Image` object is passed to the `numpy.array` function. Reasons:

1. Integration with specific third-party libraries is out-of-scope.
2. If we ever add this, a method `to_numpy_array` would be preferable, since it's more visible and clearer. `__array__` could mean anything.