### PR TITLE
feat: make `data` parameter of `Table` and `Column` required

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -68,11 +68,8 @@ class Column(Sequence[T_co]):
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self, name: str, data: Sequence[T_co] | None = None) -> None:
+    def __init__(self, name: str, data: Sequence[T_co]) -> None:
         import polars as pl
-
-        if data is None:
-            data = []
 
         self._series: pl.Series = pl.Series(name, data, strict=False)
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -243,7 +243,7 @@ class Table:
             return Table._from_polars_data_frame(pl.read_json(path))
         except (pl.exceptions.PanicException, pl.exceptions.ComputeError):
             # Can happen if the JSON file is empty (https://github.com/pola-rs/polars/issues/10234)
-            return Table()
+            return Table({})
 
     @staticmethod
     def from_parquet_file(path: str | Path) -> Table:
@@ -304,11 +304,8 @@ class Table:
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self, data: Mapping[str, Sequence[Any]] | None = None) -> None:
+    def __init__(self, data: Mapping[str, Sequence[Any]]) -> None:
         import polars as pl
-
-        if data is None:
-            data = {}
 
         # Validation
         expected_length: int | None = None
@@ -487,7 +484,7 @@ class Table:
         except DuplicateError:
             # polars already validates this, so we don't need to do it again upfront (performance)
             _check_columns_dont_exist(self, [column.name for column in columns])
-            return Table()  # pragma: no cover
+            return Table({})  # pragma: no cover
 
     def add_computed_column(
         self,
@@ -1837,7 +1834,7 @@ class Table:
         +----------------------+---------+
         """
         if self.column_count == 0:
-            return Table()
+            return Table({})
 
         head = self.get_column(self.column_names[0]).summarize_statistics()
         tail = [self.get_column(name).summarize_statistics().get_column(name)._series for name in self.column_names[1:]]

--- a/tests/safeds/data/image/containers/test_image.py
+++ b/tests/safeds/data/image/containers/test_image.py
@@ -307,7 +307,7 @@ class TestEQ:
     def test_should_be_not_implemented(self, resource_path: str, device: Device) -> None:
         configure_test_with_device(device)
         image = Image.from_file(resolve_resource_path(resource_path))
-        other = Table()
+        other = Table({})
         assert (image.__eq__(other)) is NotImplemented
 
 

--- a/tests/safeds/data/image/containers/test_image_list.py
+++ b/tests/safeds/data/image/containers/test_image_list.py
@@ -746,7 +746,7 @@ class TestToJpegFiles:
 
         with tempfile.TemporaryDirectory() as tmp_parent_dir:
             tmp_files = [
-                tempfile.NamedTemporaryFile(suffix=".jpg", prefix=str(i), dir=tmp_parent_dir)
+                tempfile.NamedTemporaryFile(suffix=".jpg", prefix=str(i), dir=tmp_parent_dir)  # noqa: SIM115
                 for i in range(len(image_list))
             ]
             for tmp_file in tmp_files:
@@ -837,7 +837,7 @@ class TestToPngFiles:
 
         with tempfile.TemporaryDirectory() as tmp_parent_dir:
             tmp_files = [
-                tempfile.NamedTemporaryFile(suffix=".png", prefix=str(i), dir=tmp_parent_dir)
+                tempfile.NamedTemporaryFile(suffix=".png", prefix=str(i), dir=tmp_parent_dir)  # noqa: SIM115
                 for i in range(len(image_list))
             ]
             for tmp_file in tmp_files:

--- a/tests/safeds/data/image/containers/test_image_list.py
+++ b/tests/safeds/data/image/containers/test_image_list.py
@@ -121,7 +121,7 @@ class TestAllImageCombinations:
         assert image_list != image_list_unequal_1
         assert image_list != image_list_unequal_2
         assert image_list != image_list_unequal_3
-        assert image_list.__eq__(Table()) is NotImplemented
+        assert image_list.__eq__(Table({})) is NotImplemented
 
         # Test hash
         assert hash(image_list) == hash(image_list_clone)
@@ -1540,7 +1540,7 @@ class TestEmptyImageList:
     def test_eq(self, device: Device) -> None:
         configure_test_with_device(device)
         assert _EmptyImageList() == _EmptyImageList()
-        assert _EmptyImageList().__eq__(Table()) is NotImplemented
+        assert _EmptyImageList().__eq__(Table({})) is NotImplemented
 
     def test_hash(self, device: Device) -> None:
         configure_test_with_device(device)

--- a/tests/safeds/data/labeled/containers/_tabular_dataset/test_eq.py
+++ b/tests/safeds/data/labeled/containers/_tabular_dataset/test_eq.py
@@ -66,7 +66,7 @@ def test_should_return_whether_two_tabular_datasets_are_equal(
     ("table", "other"),
     [
         (TabularDataset({"a": [1, 2, 3], "b": [4, 5, 6]}, "b"), None),
-        (TabularDataset({"a": [1, 2, 3], "b": [4, 5, 6]}, "b"), Table()),
+        (TabularDataset({"a": [1, 2, 3], "b": [4, 5, 6]}, "b"), Table({})),
     ],
     ids=[
         "TabularDataset vs. None",

--- a/tests/safeds/data/labeled/containers/_tabular_dataset/test_eq.py
+++ b/tests/safeds/data/labeled/containers/_tabular_dataset/test_eq.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.labeled.containers import TabularDataset
 from safeds.data.tabular.containers import Table
 

--- a/tests/safeds/data/labeled/containers/_tabular_dataset/test_extras.py
+++ b/tests/safeds/data/labeled/containers/_tabular_dataset/test_extras.py
@@ -16,7 +16,7 @@ from safeds.data.tabular.containers import Table
                 },
                 target_name="T",
             ),
-            Table(),
+            Table({}),
         ),
         (
             TabularDataset(

--- a/tests/safeds/data/labeled/containers/_tabular_dataset/test_extras.py
+++ b/tests/safeds/data/labeled/containers/_tabular_dataset/test_extras.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.labeled.containers import TabularDataset
 from safeds.data.tabular.containers import Table
 

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_eq.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_eq.py
@@ -101,7 +101,7 @@ def test_should_return_whether_two_tabular_datasets_are_equal(
         ),
         (
             TimeSeriesDataset({"a": [1, 2, 3], "b": [4, 5, 6], "c": [0, 0, 0]}, "b", window_size=1),
-            Table(),
+            Table({}),
         ),
     ],
     ids=[

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_eq.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_eq.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.labeled.containers import TimeSeriesDataset
 from safeds.data.tabular.containers import Table
 

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_extras.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_extras.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.labeled.containers import TimeSeriesDataset
 from safeds.data.tabular.containers import Table
 

--- a/tests/safeds/data/labeled/containers/_time_series_dataset/test_extras.py
+++ b/tests/safeds/data/labeled/containers/_time_series_dataset/test_extras.py
@@ -17,7 +17,7 @@ from safeds.data.tabular.containers import Table
                 target_name="T",
                 window_size=1,
             ),
-            Table(),
+            Table({}),
         ),
         (
             TimeSeriesDataset(

--- a/tests/safeds/data/labeled/containers/test_image_dataset.py
+++ b/tests/safeds/data/labeled/containers/test_image_dataset.py
@@ -5,6 +5,9 @@ from typing import TypeVar
 
 import pytest
 import torch
+from torch import Tensor
+from torch.types import Device
+
 from safeds._config import _get_device
 from safeds.data.image.containers import ImageList
 from safeds.data.image.containers._empty_image_list import _EmptyImageList
@@ -20,9 +23,6 @@ from safeds.exceptions import (
     OutputLengthMismatchError,
     TransformerNotFittedError,
 )
-from torch import Tensor
-from torch.types import Device
-
 from tests.helpers import (
     configure_test_with_device,
     get_devices,

--- a/tests/safeds/data/labeled/containers/test_image_dataset.py
+++ b/tests/safeds/data/labeled/containers/test_image_dataset.py
@@ -43,11 +43,11 @@ class TestImageDatasetInit:
         [
             (
                 _MultiSizeImageList(),
-                Table(),
+                Table({}),
                 ValueError,
                 r"The given input ImageList contains images of different sizes.",
             ),
-            (_EmptyImageList(), Table(), ValueError, r"The given input ImageList contains no images."),
+            (_EmptyImageList(), Table({}), ValueError, r"The given input ImageList contains no images."),
             (
                 ImageList.from_files(resolve_resource_path([plane_png_path, plane_png_path])),
                 ImageList.from_files(resolve_resource_path([plane_png_path, white_square_png_path])),
@@ -62,7 +62,7 @@ class TestImageDatasetInit:
             ),
             (
                 ImageList.from_files(resolve_resource_path(plane_png_path)),
-                Table(),
+                Table({}),
                 OutputLengthMismatchError,
                 r"The length of the output container differs",
             ),
@@ -210,7 +210,7 @@ class TestEq:
     def test_should_be_not_implemented(self, device: Device) -> None:
         configure_test_with_device(device)
         image_dataset = ImageDataset(ImageList.from_files(resolve_resource_path(plane_png_path)), Column("images", [1]))
-        other = Table()
+        other = Table({})
         assert image_dataset.__eq__(other) is NotImplemented
 
 
@@ -510,7 +510,7 @@ class TestTableAsTensor:
 
     def test_eq_should_be_not_implemented(self, device: Device) -> None:
         configure_test_with_device(device)
-        assert _TableAsTensor(Table()).__eq__(Table()) is NotImplemented
+        assert _TableAsTensor(Table({})).__eq__(Table({})) is NotImplemented
 
 
 @pytest.mark.parametrize("device", get_devices(), ids=get_devices_ids())
@@ -554,7 +554,7 @@ class TestColumnAsTensor:
 
     def test_eq_should_be_not_implemented(self, device: Device) -> None:
         configure_test_with_device(device)
-        assert _ColumnAsTensor(Column("column", [1])).__eq__(Table()) is NotImplemented
+        assert _ColumnAsTensor(Column("column", [1])).__eq__(Table({})) is NotImplemented
 
     def test_should_not_warn(self, device: Device) -> None:
         configure_test_with_device(device)

--- a/tests/safeds/data/tabular/containers/_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_equals.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import polars as pl
 import pytest
+
 from safeds.data.tabular.containers import Cell, Table
 from safeds.data.tabular.containers._lazy_cell import _LazyCell
 

--- a/tests/safeds/data/tabular/containers/_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_cell/test_equals.py
@@ -30,7 +30,7 @@ def test_should_return_true_if_objects_are_identical() -> None:
     ("cell", "other"),
     [
         (_LazyCell(pl.col("a")), None),
-        (_LazyCell(pl.col("a")), Table()),
+        (_LazyCell(pl.col("a")), Table({})),
     ],
     ids=[
         "Cell vs. None",

--- a/tests/safeds/data/tabular/containers/_column/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_column/test_eq.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_column/test_eq.py
@@ -44,7 +44,7 @@ def test_should_return_true_if_objects_are_identical(column: Column) -> None:
     ("column", "other"),
     [
         (Column("a"), None),
-        (Column("a", [1, 2, 3]), Table()),
+        (Column("a", [1, 2, 3]), Table({})),
     ],
     ids=[
         "Column vs. None",

--- a/tests/safeds/data/tabular/containers/_column/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_column/test_eq.py
@@ -7,9 +7,9 @@ from safeds.data.tabular.containers import Column, Table
 @pytest.mark.parametrize(
     ("column1", "column2", "expected"),
     [
-        (Column("a"), Column("a"), True),
+        (Column("a", []), Column("a", []), True),
         (Column("a", [1, 2, 3]), Column("a", [1, 2, 3]), True),
-        (Column("a"), Column("b"), False),
+        (Column("a", []), Column("b", []), False),
         (Column("a", [1, 2, 3]), Column("a", [1, 2, 4]), False),
         (Column("a", [1, 2, 3]), Column("a", ["1", "2", "3"]), False),
     ],
@@ -28,7 +28,7 @@ def test_should_return_whether_two_columns_are_equal(column1: Column, column2: C
 @pytest.mark.parametrize(
     "column",
     [
-        Column("a"),
+        Column("a", []),
         Column("a", [1, 2, 3]),
     ],
     ids=[
@@ -43,7 +43,7 @@ def test_should_return_true_if_objects_are_identical(column: Column) -> None:
 @pytest.mark.parametrize(
     ("column", "other"),
     [
-        (Column("a"), None),
+        (Column("a", []), None),
         (Column("a", [1, 2, 3]), Table({})),
     ],
     ids=[

--- a/tests/safeds/data/tabular/containers/_column/test_hash.py
+++ b/tests/safeds/data/tabular/containers/_column/test_hash.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_hash.py
+++ b/tests/safeds/data/tabular/containers/_column/test_hash.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.containers import Column
 @pytest.mark.parametrize(
     ("column", "expected"),
     [
-        (Column("a"), 1581717131331298536),
+        (Column("a", []), 1581717131331298536),
         (Column("a", [1, 2, 3]), 239695622656180157),
     ],
     ids=[
@@ -20,9 +20,9 @@ def test_should_be_deterministic(column: Column, expected: int) -> None:
 @pytest.mark.parametrize(
     ("column1", "column2", "expected"),
     [
-        (Column("a"), Column("a"), True),
+        (Column("a", []), Column("a", []), True),
         (Column("a", [1, 2, 3]), Column("a", [1, 2, 3]), True),
-        (Column("a"), Column("b"), False),
+        (Column("a", []), Column("b", []), False),
         (Column("a", [1, 2, 3]), Column("a", [1, 2]), False),
         (Column("a", [1, 2, 3]), Column("a", ["1", "2", "3"]), False),
         # We don't use the column values in the hash calculation

--- a/tests/safeds/data/tabular/containers/_column/test_init.py
+++ b/tests/safeds/data/tabular/containers/_column/test_init.py
@@ -13,13 +13,9 @@ def test_should_store_the_name() -> None:
     ("column", "expected"),
     [
         (Column("a", []), []),
-        (Column("a", None), []),
-        (Column("a", []), []),
         (Column("a", [1, 2, 3]), [1, 2, 3]),
     ],
     ids=[
-        "none (implicit)",
-        "none (explicit)",
         "empty",
         "non-empty",
     ],

--- a/tests/safeds/data/tabular/containers/_column/test_init.py
+++ b/tests/safeds/data/tabular/containers/_column/test_init.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Column
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_init.py
+++ b/tests/safeds/data/tabular/containers/_column/test_init.py
@@ -12,7 +12,7 @@ def test_should_store_the_name() -> None:
 @pytest.mark.parametrize(
     ("column", "expected"),
     [
-        (Column("a"), []),
+        (Column("a", []), []),
         (Column("a", None), []),
         (Column("a", []), []),
         (Column("a", [1, 2, 3]), [1, 2, 3]),

--- a/tests/safeds/data/tabular/containers/_row/test_column_count.py
+++ b/tests/safeds/data/tabular/containers/_row/test_column_count.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), 0),
+        (Table({}), 0),
         (Table({"A": [1, 2, 3]}), 1),
     ],
     ids=[

--- a/tests/safeds/data/tabular/containers/_row/test_get_cell.py
+++ b/tests/safeds/data/tabular/containers/_row/test_get_cell.py
@@ -30,7 +30,7 @@ def test_should_get_correct_item(table_data: dict, column_name: str, target: int
 @pytest.mark.parametrize(
     ("table", "column_name"),
     [
-        (Table(), "A"),
+        (Table({}), "A"),
         (Table({"A": ["a", "aa", "aaa"]}), "B"),
         (Table({"A": ["b", "aa", "aaa"], "C": ["b", "aa", "aaa"]}), "B"),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_getitem.py
+++ b/tests/safeds/data/tabular/containers/_row/test_getitem.py
@@ -30,7 +30,7 @@ def test_should_get_correct_item(table_data: dict, column_name: str, target: int
 @pytest.mark.parametrize(
     ("table", "column_name"),
     [
-        (Table(), "A"),
+        (Table({}), "A"),
         (Table({"A": ["a", "aa", "aaa"]}), "B"),
         (Table({"A": ["b", "aa", "aaa"], "C": ["b", "aa", "aaa"]}), "B"),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_row/test_has_column.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table", "column_name", "expected"),
     [
-        (Table(), "A", False),
+        (Table({}), "A", False),
         (Table({"A": ["a", "aa", "aaa"]}), "A", True),
         (Table({"A": ["a", "aa", "aaa"]}), "B", False),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_hash.py
+++ b/tests/safeds/data/tabular/containers/_row/test_hash.py
@@ -7,8 +7,8 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table1", "table2", "expected"),
     [
-        (Table(), Table({"A": ["a", "aa", "aaa"]}), False),
-        (Table(), Table(), True),
+        (Table({}), Table({"A": ["a", "aa", "aaa"]}), False),
+        (Table({}), Table({}), True),
         (Table({"A": ["a", "aa", "aaa"]}), Table({"A": ["a", "aa", "aaa"]}), True),
         (Table({"A": ["a", "aa", "aaa"]}), Table({"B": ["a", "aa", "aaa"]}), False),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_iter.py
+++ b/tests/safeds/data/tabular/containers/_row/test_iter.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), []),
+        (Table({}), []),
         (Table({"A": ["a", "aa", "aaa"]}), ["A"]),
         (Table({"A": ["a", "aa", "aaa"], "B": ["b", "bb", "bbb"], "C": ["c", "cc", "ccc"]}), ["A", "B", "C"]),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_len.py
+++ b/tests/safeds/data/tabular/containers/_row/test_len.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), 0),
+        (Table({}), 0),
         (Table({"A": ["a", "aa", "aaa"]}), 1),
         (Table({"A": ["a", "aa", "aaa"], "B": ["b", "bb", "bbb"]}), 2),
     ],

--- a/tests/safeds/data/tabular/containers/_row/test_schema.py
+++ b/tests/safeds/data/tabular/containers/_row/test_schema.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers._lazy_vectorized_row import _LazyVectorizedR
 @pytest.mark.parametrize(
     ("table"),
     [
-        (Table()),
+        (Table({})),
         (Table({"A": ["a", "aa", "aaa"]})),
         (Table({"A": ["a", "aa", "aaa"], "B": ["b", "bb", "bbb"]})),
     ],

--- a/tests/safeds/data/tabular/containers/_string_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_string_cell/test_equals.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import polars as pl
 import pytest
+
 from safeds.data.tabular.containers import StringCell, Table
 from safeds.data.tabular.containers._lazy_string_cell import _LazyStringCell
 

--- a/tests/safeds/data/tabular/containers/_string_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_string_cell/test_equals.py
@@ -30,7 +30,7 @@ def test_should_return_true_if_objects_are_identical() -> None:
     ("cell", "other"),
     [
         (_LazyStringCell(pl.col("a")), None),
-        (_LazyStringCell(pl.col("a")), Table()),
+        (_LazyStringCell(pl.col("a")), Table({})),
     ],
     ids=[
         "Cell vs. None",

--- a/tests/safeds/data/tabular/containers/_table/test_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import DuplicateColumnError
 

--- a/tests/safeds/data/tabular/containers/_table/test_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_column.py
@@ -19,12 +19,12 @@ from safeds.exceptions import DuplicateColumnError
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4], "col3": [0, -1, -2]}),
         ),
         (
-            Table(),
+            Table({}),
             Column("col3", []),
             Table({"col3": []}),
         ),
         (
-            Table(),
+            Table({}),
             Column("col3", [1]),
             Table({"col3": [1]}),
         ),

--- a/tests/safeds/data/tabular/containers/_table/test_add_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_columns.py
@@ -11,12 +11,12 @@ from safeds.data.tabular.containers import Column, Table
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4], "col3": [0, -1, -2], "col4": ["a", "b", "c"]}),
         ),
         (
-            Table(),
+            Table({}),
             [Column("col3", []), Column("col4", [])],
             Table({"col3": [], "col4": []}),
         ),
         (
-            Table(),
+            Table({}),
             [Column("col3", [1]), Column("col4", [2])],
             Table({"col3": [1], "col4": [2]}),
         ),
@@ -37,10 +37,10 @@ def test_should_add_columns(table1: Table, columns: list[Column], expected: Tabl
             Table({"col3": [0, -1, -2], "col4": ["a", "b", "c"]}),
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4], "col3": [0, -1, -2], "col4": ["a", "b", "c"]}),
         ),
-        (Table(), Table({"col1": [1, 2], "col2": [60, 2]}), Table({"col1": [1, 2], "col2": [60, 2]})),
+        (Table({}), Table({"col1": [1, 2], "col2": [60, 2]}), Table({"col1": [1, 2], "col2": [60, 2]})),
         (
             Table({"col1": [1, 2], "col2": [60, 2]}),
-            Table(),
+            Table({}),
             Table({"col1": [1, 2], "col2": [60, 2]}),
         ),
         (Table({"yeet": [], "col": []}), Table({"gg": []}), Table({"yeet": [], "col": [], "gg": []})),

--- a/tests/safeds/data/tabular/containers/_table/test_add_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_column_count.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_count.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), 0),
+        (Table({}), 0),
         (Table({"col1": []}), 1),
         (Table({"col1": [], "col2": []}), 2),
     ],

--- a/tests/safeds/data/tabular/containers/_table/test_column_count.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_count.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_column_names.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_names.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers import Table
     [
         (Table({"col1": [1], "col2": [1]}), ["col1", "col2"]),
         (Table({"col": [], "gg": []}), ["col", "gg"]),
-        (Table(), []),
+        (Table({}), []),
     ],
     ids=["Integer", "rowless", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_column_names.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_names.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_dataframe.py
+++ b/tests/safeds/data/tabular/containers/_table/test_dataframe.py
@@ -6,7 +6,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     "table",
     [
-        Table(),
+        Table({}),
         Table({"a": [1, 2], "b": [3, 4]}),
     ],
     ids=[

--- a/tests/safeds/data/tabular/containers/_table/test_dataframe.py
+++ b/tests/safeds/data/tabular/containers/_table/test_dataframe.py
@@ -1,5 +1,6 @@
 import pytest
 from polars import from_dataframe
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_table/test_eq.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_table/test_eq.py
@@ -43,7 +43,7 @@ def test_should_return_true_if_objects_are_identical(table: Table) -> None:
     ("table", "other"),
     [
         (Table({"col1": [1]}), None),
-        (Table({"col1": [1]}), Column("a")),
+        (Table({"col1": [1]}), Column("a", [])),
     ],
     ids=[
         "Table vs. None",

--- a/tests/safeds/data/tabular/containers/_table/test_eq.py
+++ b/tests/safeds/data/tabular/containers/_table/test_eq.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers import Column, Table
 @pytest.mark.parametrize(
     ("table1", "table2", "expected"),
     [
-        (Table(), Table(), True),
+        (Table({}), Table({}), True),
         (Table({"a": [], "b": []}), Table({"a": [], "b": []}), True),
         (Table({"col1": [1]}), Table({"col1": [1]}), True),
         (Table({"col1": [1]}), Table({"col2": [1]}), False),
@@ -29,7 +29,7 @@ def test_should_return_whether_two_tables_are_equal(table1: Table, table2: Table
 
 @pytest.mark.parametrize(
     "table",
-    [Table(), Table({"col1": [1]})],
+    [Table({}), Table({"col1": [1]})],
     ids=[
         "empty",
         "non-empty",

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -6,7 +6,7 @@ from safeds.exceptions import ColumnLengthMismatchError, DuplicateColumnError
 @pytest.mark.parametrize(
     ("columns", "expected"),
     [
-        ([], Table()),
+        ([], Table({})),
         (
             [
                 Column("A", [1, 2]),

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import ColumnLengthMismatchError, DuplicateColumnError
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_csv_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_csv_file.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import FileExtensionError
-
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_csv_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_csv_file.py
@@ -12,7 +12,7 @@ from tests.helpers import resolve_resource_path
     [
         ("table.csv", Table({"A": ["❔"], "B": [2]})),
         (Path("table.csv"), Table({"A": ["❔"], "B": [2]})),
-        ("emptytable.csv", Table()),
+        ("emptytable.csv", Table({})),
     ],
     ids=["by String", "by path", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_from_dict.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_dict.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnLengthMismatchError
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_dict.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_dict.py
@@ -10,7 +10,7 @@ from safeds.exceptions import ColumnLengthMismatchError
     [
         (
             {},
-            Table(),
+            Table({}),
         ),
         (
             {

--- a/tests/safeds/data/tabular/containers/_table/test_from_json_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_json_file.py
@@ -12,7 +12,7 @@ from tests.helpers import resolve_resource_path
     [
         ("table.json", Table({"A": ["❔"], "B": [2]})),
         (Path("table.json"), Table({"A": ["❔"], "B": [2]})),
-        (Path("emptytable.json"), Table()),
+        (Path("emptytable.json"), Table({})),
     ],
     ids=["by string", "by path", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_from_json_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_json_file.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import FileExtensionError
-
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_polars_dataframe.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_polars_dataframe.py
@@ -27,7 +27,7 @@
 #             Schema({"col1": String(), "col2": String()}),
 #             Table({"col1": [0, 1.1], "col2": ["a", "b"]}),
 #         ),
-#         (pd.DataFrame(), Schema({}), Schema({}), Table()),
+#         (pd.DataFrame(), Schema({}), Schema({}), Table({})),
 #     ],
 #     ids=["one row, one column", "one row, two columns", "two rows, one column", "two rows, two columns", "empty"],
 # )

--- a/tests/safeds/data/tabular/containers/_table/test_get_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_column.py
@@ -18,7 +18,7 @@ def test_should_get_column(table1: Table, expected: Column) -> None:
     "table",
     [
         (Table({"col1": ["col1_1"], "col2": ["col2_1"]})),
-        (Table()),
+        (Table({})),
     ],
     ids=["no col3", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_get_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import ColumnNotFoundError
 

--- a/tests/safeds/data/tabular/containers/_table/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_has_column.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Table
 
 @pytest.mark.parametrize(
     ("table", "column", "expected"),
-    [(Table({"A": [1], "B": [2]}), "A", True), (Table({"A": [1], "B": [2]}), "C", False), (Table(), "C", False)],
+    [(Table({"A": [1], "B": [2]}), "A", True), (Table({"A": [1], "B": [2]}), "C", False), (Table({}), "C", False)],
     ids=["has column", "doesn't have column", "empty"],
 )
 def test_should_return_if_column_is_in_table(table: Table, column: str, expected: bool) -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_has_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_hash.py
+++ b/tests/safeds/data/tabular/containers/_table/test_hash.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_hash.py
+++ b/tests/safeds/data/tabular/containers/_table/test_hash.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     ("table1", "table2"),
     [
-        (Table(), Table()),
+        (Table({}), Table({})),
         (Table({"a": [], "b": []}), Table({"a": [], "b": []})),
         (Table({"col1": [1]}), Table({"col1": [1]})),
         (Table({"col1": [1, 2, 3]}), Table({"col1": [1, 1, 3]})),

--- a/tests/safeds/data/tabular/containers/_table/test_init.py
+++ b/tests/safeds/data/tabular/containers/_table/test_init.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnLengthMismatchError
 

--- a/tests/safeds/data/tabular/containers/_table/test_init.py
+++ b/tests/safeds/data/tabular/containers/_table/test_init.py
@@ -6,7 +6,7 @@ from safeds.exceptions import ColumnLengthMismatchError
 # @pytest.mark.parametrize(
 #     ("table", "expected"),
 #     [
-#         (Table(), Schema({})),
+#         (Table({}), Schema({})),
 #         (Table({}), Schema({})),
 #         (Table({"col1": [0]}), Schema({"col1": Integer()})),
 #     ],

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnNotFoundError
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
@@ -8,19 +8,19 @@ from safeds.exceptions import ColumnNotFoundError
     ("table", "expected", "columns", "ignore_unknown_names"),
     [
         (Table({"col1": [1, 2, 1], "col2": ["a", "b", "c"]}), Table({"col1": [1, 2, 1]}), ["col2"], True),
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Table(), ["col1", "col2"], True),
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Table({}), ["col1", "col2"], True),
         (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), [], True),
-        (Table(), Table(), [], True),
-        (Table(), Table(), ["col1"], True),
+        (Table({}), Table({}), [], True),
+        (Table({}), Table({}), ["col1"], True),
         (Table({"col1": [1, 2, 1], "col2": ["a", "b", "c"]}), Table({"col1": [1, 2, 1]}), ["col2"], False),
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Table(), ["col1", "col2"], False),
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Table({}), ["col1", "col2"], False),
         (
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
             Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
             [],
             False,
         ),
-        (Table(), Table(), [], False),
+        (Table({}), Table({}), [], False),
     ],
     ids=[
         "one column, ignore unknown names",
@@ -50,8 +50,8 @@ def test_should_remove_table_columns_no_exception(
 @pytest.mark.parametrize(
     ("table", "columns", "ignore_unknown_names"),
     [
-        (Table(), ["col1"], False),
-        (Table(), ["col12"], False),
+        (Table({}), ["col1"], False),
+        (Table({}), ["col12"], False),
     ],
     ids=[
         "missing columns",

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_except.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_except.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnNotFoundError
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_except.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_except.py
@@ -9,7 +9,7 @@ from safeds.exceptions import ColumnNotFoundError
         (
             Table({"A": [1], "B": [2]}),
             [],
-            Table(),
+            Table({}),
         ),
         (
             Table({"A": [1], "B": [2]}),
@@ -33,9 +33,9 @@ from safeds.exceptions import ColumnNotFoundError
             Table({"C": [3], "A": [1]}),
         ),
         (
-            Table(),
+            Table({}),
             [],
-            Table(),
+            Table({}),
         ),
     ],
     ids=["No Column Name", "First Column", "Second Column", "All columns", "Last and first columns", "empty"],
@@ -48,7 +48,7 @@ def test_should_remove_all_except_listed_columns(table: Table, column_names: lis
         assert expected.row_count == 0
 
 
-@pytest.mark.parametrize("table", [Table({"A": [1], "B": [2]}), Table()], ids=["table", "empty"])
+@pytest.mark.parametrize("table", [Table({"A": [1], "B": [2]}), Table({})], ids=["table", "empty"])
 def test_should_raise_error_if_column_name_unknown(table: Table) -> None:
     with pytest.raises(ColumnNotFoundError):
         table.remove_columns_except(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
@@ -23,7 +23,7 @@ from safeds.data.tabular.containers import Table
                 ),
             )
         ),
-        (Table(), Table()),
+        (Table({}), Table({})),
     ],
     ids=["some missing values", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
@@ -14,7 +14,7 @@ from safeds.data.tabular.containers import Table
             ),
             Table({"A": [1, 4], "B": [2, 5]}),
         ),
-        (Table(), Table()),
+        (Table({}), Table({})),
         (Table({"col1": []}), Table({"col1": []})),
     ],
     ids=["duplicate rows", "empty", "no rows"],

--- a/tests/safeds/data/tabular/containers/_table/test_remove_non_numeric_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_non_numeric_columns.py
@@ -18,7 +18,7 @@ from safeds.data.tabular.containers import Table
                 },
             ),
         ),
-        (Table(), Table()),
+        (Table({}), Table({})),
     ],
     ids=["numerical values", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_remove_non_numeric_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_non_numeric_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
@@ -19,7 +19,7 @@ from safeds.data.tabular.containers import Table
                 },
             ),
         ),
-        (Table(), Table()),
+        (Table({}), Table({})),
     ],
     ids=["some missing values", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -248,7 +248,7 @@ from safeds.data.tabular.containers import Table
                 },
             ),
         ),
-        (Table(), Table()),
+        (Table({}), Table({})),
     ],
     ids=[
         "no outliers",

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_rename_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_rename_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnNotFoundError, DuplicateColumnError
 

--- a/tests/safeds/data/tabular/containers/_table/test_rename_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_rename_column.py
@@ -15,7 +15,7 @@ def test_should_rename_column(name_from: str, name_to: str, column_one: str, col
     assert renamed_table.column_names == [column_one, column_two]
 
 
-@pytest.mark.parametrize("table", [Table({"A": [1], "B": [2]}), Table()], ids=["normal", "empty"])
+@pytest.mark.parametrize("table", [Table({"A": [1], "B": [2]}), Table({})], ids=["normal", "empty"])
 def test_should_raise_if_old_column_does_not_exist(table: Table) -> None:
     with pytest.raises(ColumnNotFoundError):
         table.rename_column("C", "D")

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import (
     ColumnNotFoundError,

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -116,4 +116,4 @@ def test_should_raise_error(
 
 def test_should_fail_on_empty_table() -> None:
     with pytest.raises(ColumnNotFoundError):
-        Table().replace_column("col", [Column("a", [1, 2])])
+        Table({}).replace_column("col", [Column("a", [1, 2])])

--- a/tests/safeds/data/tabular/containers/_table/test_repr.py
+++ b/tests/safeds/data/tabular/containers/_table/test_repr.py
@@ -27,7 +27,7 @@ from safeds.data.tabular.containers import Table
             "+------+------+",
         ),
         (
-            Table(),
+            Table({}),
             "++\n++\n++",
         ),
         (

--- a/tests/safeds/data/tabular/containers/_table/test_repr.py
+++ b/tests/safeds/data/tabular/containers/_table/test_repr.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_repr_html.py
+++ b/tests/safeds/data/tabular/containers/_table/test_repr_html.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_repr_html.py
+++ b/tests/safeds/data/tabular/containers/_table/test_repr_html.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     "table",
     [
-        Table(),
+        Table({}),
         Table({"a": [1, 2], "b": [3, 4]}),
     ],
     ids=[
@@ -23,7 +23,7 @@ def test_should_contain_table_element(table: Table) -> None:
 @pytest.mark.parametrize(
     "table",
     [
-        Table(),
+        Table({}),
         Table({"a": [1, 2], "b": [3, 4]}),
     ],
     ids=[
@@ -39,7 +39,7 @@ def test_should_contain_th_element_for_each_column_name(table: Table) -> None:
 @pytest.mark.parametrize(
     "table",
     [
-        Table(),
+        Table({}),
         Table({"a": [1, 2], "b": [3, 4]}),
     ],
     ids=[

--- a/tests/safeds/data/tabular/containers/_table/test_row_count.py
+++ b/tests/safeds/data/tabular/containers/_table/test_row_count.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_row_count.py
+++ b/tests/safeds/data/tabular/containers/_table/test_row_count.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), 0),
+        (Table({}), 0),
         (Table({"col1": [1]}), 1),
         (Table({"col1": [1, 2]}), 2),
     ],

--- a/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     ("table", "expected"),
     [
-        (Table(), Table()),
+        (Table({}), Table({})),
         (Table({"col1": [1, 2, 3]}), Table({"col1": [3, 2, 1]})),
         (Table({"col1": [1, 2, 3], "col2": [4, 5, 6]}), Table({"col1": [3, 2, 1], "col2": [6, 5, 4]})),
     ],

--- a/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sizeof.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sizeof.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sizeof.py
@@ -7,7 +7,7 @@ from safeds.data.tabular.containers import Table
 @pytest.mark.parametrize(
     "table",
     [
-        Table(),
+        Table({}),
         Table({"col1": [0]}),
         Table({"col1": [0, 1], "col2": ["a", "b"]}),
     ],

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -7,10 +7,10 @@ from safeds.exceptions import OutOfBoundsError
     ("table", "start", "length", "expected"),
     [
         (
-            Table(),
+            Table({}),
             0,
             None,
-            Table(),
+            Table({}),
         ),
         (
             Table({"col1": []}),
@@ -78,6 +78,6 @@ def test_should_slice_rows(table: Table, start: int, length: int | None, expecte
 
 
 def test_should_raise_for_negative_length() -> None:
-    table: Table = Table()
+    table: Table = Table({})
     with pytest.raises(OutOfBoundsError):
         table.slice_rows(0, -1)

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import OutOfBoundsError
 

--- a/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 import pytest
+
 from safeds.data.tabular.containers import Cell, Row, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
@@ -8,9 +8,9 @@ from safeds.data.tabular.containers import Cell, Row, Table
     ("table", "key_selector", "expected"),
     [
         (
-            Table(),
+            Table({}),
             lambda row: row["col1"],
-            Table(),
+            Table({}),
         ),
         (
             Table({"col1": [3, 2, 1]}),
@@ -33,9 +33,9 @@ def test_should_return_sorted_table(
     ("table", "key_selector", "expected"),
     [
         (
-            Table(),
+            Table({}),
             lambda row: row["col1"],
-            Table(),
+            Table({}),
         ),
         (
             Table({"col1": [3, 2, 1]}),

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -53,6 +53,6 @@ def test_should_raise_if_value_not_in_range(percentage_in_first: float) -> None:
 
 
 def test_should_split_empty_table() -> None:
-    t1, t2 = Table().split_rows(0.4)
+    t1, t2 = Table({}).split_rows(0.4)
     assert t1.row_count == 0
     assert t2.row_count == 0

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import OutOfBoundsError
 

--- a/tests/safeds/data/tabular/containers/_table/test_str.py
+++ b/tests/safeds/data/tabular/containers/_table/test_str.py
@@ -27,7 +27,7 @@ from safeds.data.tabular.containers import Table
             "+------+------+",
         ),
         (
-            Table(),
+            Table({}),
             "++\n++\n++",
         ),
         (

--- a/tests/safeds/data/tabular/containers/_table/test_str.py
+++ b/tests/safeds/data/tabular/containers/_table/test_str.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
@@ -48,8 +48,8 @@ from safeds.data.tabular.containers import Table
             ),
         ),
         (
-            Table(),
-            Table(),
+            Table({}),
+            Table({}),
         ),
         (
             Table({"col": [], "gg": []}),

--- a/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
@@ -1,6 +1,7 @@
 from statistics import stdev
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Column, Table
 
 @pytest.mark.parametrize(
     ("table", "expected"),
-    [(Table({"A": [54, 74], "B": [90, 2010]}), [Column("A", [54, 74]), Column("B", [90, 2010])]), (Table(), [])],
+    [(Table({"A": [54, 74], "B": [90, 2010]}), [Column("A", [54, 74]), Column("B", [90, 2010])]), (Table({}), [])],
     ids=["normal", "empty"],
 )
 def test_should_return_list_of_columns(table: Table, expected: list[Column]) -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
@@ -2,9 +2,9 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import FileExtensionError
-
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
@@ -12,7 +12,7 @@ from tests.helpers import resolve_resource_path
     "table",
     [
         (Table({"col1": ["col1_1"], "col2": ["col2_1"]})),
-        (Table()),
+        (Table({})),
     ],
     ids=["by String", "empty"],
 )
@@ -35,7 +35,7 @@ def test_should_create_csv_file_from_table_by_str(table: Table) -> None:
     "table",
     [
         (Table({"col1": ["col1_1"], "col2": ["col2_1"]})),
-        (Table()),
+        (Table({})),
     ],
     ids=["by String", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_to_dict.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_dict.py
@@ -8,7 +8,7 @@ from safeds.data.tabular.containers import Table
     ("table", "expected"),
     [
         (
-            Table(),
+            Table({}),
             {},
         ),
         (

--- a/tests/safeds/data/tabular/containers/_table/test_to_dict.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_dict.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import FileExtensionError
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
@@ -10,7 +10,7 @@ from safeds.exceptions import FileExtensionError
     "table",
     [
         (Table({"col1": ["col1_1"], "col2": ["col2_1"]})),
-        (Table()),
+        (Table({})),
     ],
     ids=["by String", "empty"],
 )
@@ -29,7 +29,7 @@ def test_should_create_json_file_from_table_by_str(table: Table) -> None:
     "table",
     [
         (Table({"col1": ["col1_1"], "col2": ["col2_1"]})),
-        (Table()),
+        (Table({})),
     ],
     ids=["by String", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_transform_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_column.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnNotFoundError
 

--- a/tests/safeds/data/tabular/containers/_table/test_transform_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_column.py
@@ -30,7 +30,7 @@ def test_should_transform_column(table: Table, table_transformed: Table) -> None
                 "C": ["a", "b", "c"],
             },
         ),
-        Table(),
+        Table({}),
     ],
     ids=["column not found", "empty"],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_transform_table.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_table.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import OneHotEncoder
 from safeds.exceptions import ColumnNotFoundError, TransformerNotFittedError

--- a/tests/safeds/data/tabular/containers/_table/test_transform_table.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_table.py
@@ -91,7 +91,7 @@ def test_should_return_transformed_table(
                 "col1": ["a", "b", "c"],
             },
         ),
-        Table(),
+        Table({}),
     ],
     ids=["non-empty table", "empty table"],
 )

--- a/tests/safeds/data/tabular/containers/_temporal_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_temporal_cell/test_equals.py
@@ -30,7 +30,7 @@ def test_should_return_true_if_objects_are_identical() -> None:
     ("cell", "other"),
     [
         (_LazyTemporalCell(pl.col("a")), None),
-        (_LazyTemporalCell(pl.col("a")), Table()),
+        (_LazyTemporalCell(pl.col("a")), Table({})),
     ],
     ids=[
         "Cell vs. None",

--- a/tests/safeds/data/tabular/containers/_temporal_cell/test_equals.py
+++ b/tests/safeds/data/tabular/containers/_temporal_cell/test_equals.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import polars as pl
 import pytest
+
 from safeds.data.tabular.containers import Table, TemporalCell
 from safeds.data.tabular.containers._lazy_temporal_cell import _LazyTemporalCell
 

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -173,7 +173,7 @@
 #         ("row", "other"),
 #         [
 #             (Row({"col1": 0}), None),
-#             (Row({"col1": 0}), Table()),
+#             (Row({"col1": 0}), Table({})),
 #         ],
 #         ids=[
 #             "Row vs. None",

--- a/tests/safeds/data/tabular/plotting/test_plot_boxplots.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_boxplots.py
@@ -1,7 +1,8 @@
 import pytest
+from syrupy import SnapshotAssertion
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import NonNumericColumnError
-from syrupy import SnapshotAssertion
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_boxplots.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_boxplots.py
@@ -32,7 +32,7 @@ def test_should_raise_if_column_contains_non_numerical_values() -> None:
 
 def test_should_fail_on_empty_table() -> None:
     with pytest.raises(NonNumericColumnError):
-        Table().plot.box_plots()
+        Table({}).plot.box_plots()
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_correlation_heatmap.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_correlation_heatmap.py
@@ -1,6 +1,7 @@
 import pytest
-from safeds.data.tabular.containers import Table
 from syrupy import SnapshotAssertion
+
+from safeds.data.tabular.containers import Table
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_correlation_heatmap.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_correlation_heatmap.py
@@ -21,7 +21,7 @@ def test_should_match_snapshot(table: Table, snapshot_png_image: SnapshotAsserti
 #         UserWarning,
 #         match=r"An empty table has been used. A correlation heatmap on an empty table will show nothing.",
 #     ):
-#         Table().plot.correlation_heatmap()
+#         Table({}).plot.correlation_heatmap()
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_histogram_2d.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_histogram_2d.py
@@ -51,7 +51,7 @@ def test_should_match_snapshot(
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "C", "A"),
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "B", "C"),
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "C", "D"),
-        (Table(), "C", "D"),
+        (Table({}), "C", "D"),
     ],
     ids=[
         "First argument doesn't exist",

--- a/tests/safeds/data/tabular/plotting/test_plot_histogram_2d.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_histogram_2d.py
@@ -1,8 +1,8 @@
 import pytest
-from safeds.data.tabular.containers import Table
-from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, OutOfBoundsError
 from syrupy import SnapshotAssertion
 
+from safeds.data.tabular.containers import Table
+from safeds.exceptions import ColumnNotFoundError, ColumnTypeError, OutOfBoundsError
 from tests.helpers import os_mac, skip_if_os
 
 

--- a/tests/safeds/data/tabular/plotting/test_plot_histograms.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_histograms.py
@@ -1,6 +1,7 @@
 import pytest
-from safeds.data.tabular.containers import Table
 from syrupy import SnapshotAssertion
+
+from safeds.data.tabular.containers import Table
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_histograms.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_histograms.py
@@ -73,7 +73,7 @@ def test_should_match_snapshot(table: Table, snapshot_png_image: SnapshotAsserti
 
 def test_should_fail_on_empty_table() -> None:
     with pytest.raises(ZeroDivisionError):
-        Table().plot.histograms()
+        Table({}).plot.histograms()
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_lineplot.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_lineplot.py
@@ -1,8 +1,8 @@
 import pytest
-from safeds.data.tabular.containers import Table
-from safeds.exceptions import ColumnNotFoundError
 from syrupy import SnapshotAssertion
 
+from safeds.data.tabular.containers import Table
+from safeds.exceptions import ColumnNotFoundError
 from tests.helpers import os_mac, skip_if_os
 
 

--- a/tests/safeds/data/tabular/plotting/test_plot_lineplot.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_lineplot.py
@@ -47,7 +47,7 @@ def test_should_not_match_snapshot_without_confidence(snapshot_png_image: Snapsh
     [
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "C", "A"),
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "A", "C"),
-        (Table(), "x", "y"),
+        (Table({}), "x", "y"),
     ],
     ids=["x column", "y column", "empty"],
 )

--- a/tests/safeds/data/tabular/plotting/test_plot_scatterplot.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_scatterplot.py
@@ -1,7 +1,8 @@
 import pytest
+from syrupy import SnapshotAssertion
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import ColumnNotFoundError, ColumnTypeError
-from syrupy import SnapshotAssertion
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_scatterplot.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_scatterplot.py
@@ -86,7 +86,7 @@ def test_should_match_snapshot_dark(
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "C", "A"),
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "B", "C"),
         (Table({"A": [1, 2, 3], "B": [2, 4, 7]}), "C", "D"),
-        (Table(), "C", "D"),
+        (Table({}), "C", "D"),
     ],
     ids=["First argument doesn't exist", "Second argument doesn't exist", "Both arguments do not exist", "empty"],
 )

--- a/tests/safeds/data/tabular/plotting/test_plot_violin_plots.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_violin_plots.py
@@ -1,7 +1,8 @@
 import pytest
+from syrupy import SnapshotAssertion
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import NonNumericColumnError
-from syrupy import SnapshotAssertion
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/plotting/test_plot_violin_plots.py
+++ b/tests/safeds/data/tabular/plotting/test_plot_violin_plots.py
@@ -46,4 +46,4 @@ def test_should_raise_if_column_contains_non_numerical_values() -> None:
 
 def test_should_fail_on_empty_table() -> None:
     with pytest.raises(NonNumericColumnError):
-        Table().plot.violin_plots()
+        Table({}).plot.violin_plots()

--- a/tests/safeds/data/tabular/transformation/test_discretizer.py
+++ b/tests/safeds/data/tabular/transformation/test_discretizer.py
@@ -1,4 +1,5 @@
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import Discretizer
 from safeds.exceptions import (

--- a/tests/safeds/data/tabular/transformation/test_discretizer.py
+++ b/tests/safeds/data/tabular/transformation/test_discretizer.py
@@ -42,7 +42,7 @@ class TestFit:
                 ColumnNotFoundError,
                 None,
             ),
-            (Table(), ["col2"], ValueError, "The Discretizer cannot be fitted because the table contains 0 rows"),
+            (Table({}), ["col2"], ValueError, "The Discretizer cannot be fitted because the table contains 0 rows"),
             (
                 Table(
                     {
@@ -105,7 +105,7 @@ class TestTransform:
                 ColumnNotFoundError,
                 None,
             ),
-            (Table(), ["col1", "col3"], ValueError, "The table cannot be transformed because it contains 0 rows"),
+            (Table({}), ["col1", "col3"], ValueError, "The table cannot be transformed because it contains 0 rows"),
             (
                 Table(
                     {

--- a/tests/safeds/ml/nn/converters/test_input_converter_image.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_image.py
@@ -107,7 +107,7 @@ class TestEq:
 
     def test_should_be_not_implemented(self) -> None:
         input_conversion_image = InputConversionImageToImage(ImageSize(1, 2, 3))
-        other = Table()
+        other = Table({})
         assert input_conversion_image.__eq__(other) is NotImplemented
 
 

--- a/tests/safeds/ml/nn/converters/test_input_converter_image.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_image.py
@@ -1,12 +1,12 @@
 import sys
 
 import pytest
+
 from safeds.data.image.containers import ImageList
 from safeds.data.image.typing import ImageSize
 from safeds.data.labeled.containers import ImageDataset
 from safeds.data.tabular.containers import Column, Table
 from safeds.ml.nn.converters import InputConversionImageToImage
-
 from tests.helpers import images_all, resolve_resource_path
 
 _test_image_list = ImageList.from_files(resolve_resource_path(images_all())).resize(10, 10)

--- a/tests/safeds/ml/nn/converters/test_input_converter_image_2.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_image_2.py
@@ -51,7 +51,7 @@ class TestDataConversionImage:
             output_conversion_image_to_image = InputConversionImageToImage(ImageSize(1, 1, 1))
             output_conversion_image_to_table = InputConversionImageToTable(ImageSize(1, 1, 1))
             output_conversion_image_to_column = InputConversionImageToColumn(ImageSize(1, 1, 1))
-            other = Table()
+            other = Table({})
             assert output_conversion_image_to_image.__eq__(other) is NotImplemented
             assert output_conversion_image_to_image.__eq__(output_conversion_image_to_table) is NotImplemented
             assert output_conversion_image_to_image.__eq__(output_conversion_image_to_column) is NotImplemented

--- a/tests/safeds/ml/nn/converters/test_input_converter_image_2.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_image_2.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 import torch
+
 from safeds.data.image.containers._multi_size_image_list import _MultiSizeImageList
 from safeds.data.image.containers._single_size_image_list import _SingleSizeImageList
 from safeds.data.image.typing import ImageSize

--- a/tests/safeds/ml/nn/converters/test_input_converter_time_series.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_time_series.py
@@ -55,7 +55,7 @@ class TestEq:
         [
             (
                 InputConversionTimeSeries(),
-                Table(),
+                Table({}),
             ),
         ],
     )

--- a/tests/safeds/ml/nn/converters/test_input_converter_time_series.py
+++ b/tests/safeds/ml/nn/converters/test_input_converter_time_series.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.ml.nn import (
     NeuralNetworkRegressor,

--- a/tests/safeds/ml/nn/layers/test_dropout_layer.py
+++ b/tests/safeds/ml/nn/layers/test_dropout_layer.py
@@ -1,11 +1,12 @@
 import sys
 
 import pytest
+from torch import nn
+
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import OutOfBoundsError
 from safeds.ml.nn.layers import DropoutLayer
 from safeds.ml.nn.typing import ConstantImageSize
-from torch import nn
 
 
 class TestProbability:

--- a/tests/safeds/ml/nn/layers/test_dropout_layer.py
+++ b/tests/safeds/ml/nn/layers/test_dropout_layer.py
@@ -49,7 +49,7 @@ class TestEq:
         assert DropoutLayer(0.5) == DropoutLayer(0.5)
 
     def test_should_be_not_implemented(self) -> None:
-        assert DropoutLayer(0.5).__eq__(Table()) is NotImplemented
+        assert DropoutLayer(0.5).__eq__(Table({})) is NotImplemented
 
 
 class TestHash:

--- a/tests/safeds/ml/nn/layers/test_flatten_layer.py
+++ b/tests/safeds/ml/nn/layers/test_flatten_layer.py
@@ -42,7 +42,7 @@ class TestFlattenLayer:
             assert FlattenLayer() == FlattenLayer()
 
         def test_should_be_not_implemented(self) -> None:
-            assert FlattenLayer().__eq__(Table()) is NotImplemented
+            assert FlattenLayer().__eq__(Table({})) is NotImplemented
 
     class TestHash:
         def test_hash_should_be_equal(self) -> None:

--- a/tests/safeds/ml/nn/layers/test_flatten_layer.py
+++ b/tests/safeds/ml/nn/layers/test_flatten_layer.py
@@ -1,11 +1,12 @@
 import sys
 
 import pytest
+from torch import nn
+
 from safeds.data.image.typing import ImageSize
 from safeds.data.tabular.containers import Table
 from safeds.ml.nn.layers import FlattenLayer
 from safeds.ml.nn.typing import VariableImageSize
-from torch import nn
 
 
 class TestFlattenLayer:

--- a/tests/safeds/ml/nn/layers/test_pooling2d_layer.py
+++ b/tests/safeds/ml/nn/layers/test_pooling2d_layer.py
@@ -2,11 +2,12 @@ import sys
 from typing import Literal
 
 import pytest
+from torch import nn
+
 from safeds.data.image.typing import ImageSize
 from safeds.data.tabular.containers import Table
 from safeds.ml.nn.layers import AveragePooling2DLayer, MaxPooling2DLayer
 from safeds.ml.nn.layers._pooling2d_layer import _Pooling2DLayer
-from torch import nn
 
 
 class TestPooling2DLayer:

--- a/tests/safeds/ml/nn/layers/test_pooling2d_layer.py
+++ b/tests/safeds/ml/nn/layers/test_pooling2d_layer.py
@@ -105,7 +105,7 @@ class TestPooling2DLayer:
         def test_should_be_not_implemented(self) -> None:
             max_pooling_2d_layer = MaxPooling2DLayer(1)
             avg_pooling_2d_layer = AveragePooling2DLayer(1)
-            other = Table()
+            other = Table({})
             assert max_pooling_2d_layer.__eq__(other) is NotImplemented
             assert max_pooling_2d_layer.__eq__(avg_pooling_2d_layer) is NotImplemented
             assert avg_pooling_2d_layer.__eq__(other) is NotImplemented


### PR DESCRIPTION
### Summary of Changes

The `data` parameter of `Table` and `Column` must now be specified. Being able to omit it was nice for tests, but also means that users might forget to specify their data. Since tables and columns are immutable, creating an empty table is rarely useful in practice.
