### PR TITLE
fix: handling of missing value in `removeRows`/`removeRowsByColumn`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1529,7 +1529,7 @@ class Table:
         mask = predicate(_LazyVectorizedRow(self))
 
         return Table._from_polars_lazy_frame(
-            self._lazy_frame.filter(~mask._polars_expression),
+            self._lazy_frame.remove(mask._polars_expression),
         )
 
     def remove_rows_by_column(
@@ -1592,7 +1592,7 @@ class Table:
         mask = predicate(_LazyCell(pl.col(name)))
 
         return Table._from_polars_lazy_frame(
-            self._lazy_frame.filter(~mask._polars_expression),
+            self._lazy_frame.remove(mask._polars_expression),
         )
 
     def remove_rows_with_missing_values(

--- a/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
@@ -33,6 +33,11 @@ from safeds.data.tabular.containers import Cell, Row, Table
             lambda row: row["col1"] <= 2,
             Table({"col1": [1, 2]}),
         ),
+        (
+            lambda: Table({"col1": [None]}),
+            lambda row: row["col1"] <= 2,
+            Table({"col1": []}),
+        ),
     ],
     ids=[
         "empty",
@@ -40,6 +45,7 @@ from safeds.data.tabular.containers import Cell, Row, Table
         "no matches",
         "some matches",
         "only matches",
+        "None",
     ],
 )
 class TestHappyPath:

--- a/tests/safeds/data/tabular/containers/_table/test_filter_rows_by_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_filter_rows_by_column.py
@@ -33,12 +33,19 @@ from safeds.exceptions import ColumnNotFoundError
             lambda cell: cell <= 2,
             Table({"col1": [1, 2], "col2": [-1, -2]}),
         ),
+        (
+            lambda: Table({"col1": [None], "col2": [None]}),
+            "col1",
+            lambda cell: cell <= 2,
+            Table({"col1": [], "col2": []}),
+        ),
     ],
     ids=[
         "no rows",
         "no matches",
         "some matches",
         "only matches",
+        "None",
     ],
 )
 class TestHappyPath:

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows.py
@@ -33,6 +33,11 @@ from safeds.data.tabular.containers import Cell, Row, Table
             lambda row: row["col1"] <= 2,
             Table({"col1": []}),
         ),
+        (
+            lambda: Table({"col1": [None]}),
+            lambda row: row["col1"] <= 2,
+            Table({"col1": [None]}),
+        ),
     ],
     ids=[
         "empty",
@@ -40,6 +45,7 @@ from safeds.data.tabular.containers import Cell, Row, Table
         "no matches",
         "some matches",
         "only matches",
+        "None",
     ],
 )
 class TestHappyPath:

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_by_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_by_column.py
@@ -33,12 +33,19 @@ from safeds.exceptions import ColumnNotFoundError
             lambda cell: cell <= 2,
             Table({"col1": [], "col2": []}),
         ),
+        (
+            lambda: Table({"col1": [None], "col2": [None]}),
+            "col1",
+            lambda cell: cell <= 2,
+            Table({"col1": [None], "col2": [None]}),
+        ),
     ],
     ids=[
         "no rows",
         "no matches",
         "some matches",
         "only matches",
+        "None",
     ],
 )
 class TestHappyPath:


### PR DESCRIPTION
Closes #998

### Summary of Changes

`Table.removeRows` and `Table.removeRowsByColumn` now keep missing values, i.e. they only remove rows for which the predicate returns `True`.